### PR TITLE
Group API 구현 및 그룹 생성 규칙 생성

### DIFF
--- a/src/main/kotlin/com/wafflestudio/spring2025/group/GroupException.kt
+++ b/src/main/kotlin/com/wafflestudio/spring2025/group/GroupException.kt
@@ -23,6 +23,12 @@ class GroupNameConflictException : GroupException(
     msg = "Group name already exists",
 )
 
+class CreateBadGroupNameException : GroupException(
+    errorCode = 0,
+    httpStatusCode = HttpStatus.BAD_REQUEST,
+    msg = "Bad groupname",
+)
+
 class GroupCodeConflictException : GroupException(
     errorCode = 0,
     httpStatusCode = HttpStatus.CONFLICT,

--- a/src/main/kotlin/com/wafflestudio/spring2025/group/controller/GroupController.kt
+++ b/src/main/kotlin/com/wafflestudio/spring2025/group/controller/GroupController.kt
@@ -10,6 +10,7 @@ import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
@@ -36,19 +37,25 @@ class GroupController(
     )
     @PostMapping
     fun create(@RequestBody request: CreateGroupRequest): ResponseEntity<CreateGroupResponse> {
-        TODO("동아리 생성 API 구현")
+        val group =
+            groupService.create(
+                name = request.name,
+                detail = request.detail,
+            )
+        return ResponseEntity.status(HttpStatus.CREATED).body(CreateGroupResponse(group))
     }
 
     @Operation(summary = "동아리 목록 조회", description = "모든 동아리 목록을 조회합니다")
     @GetMapping
     fun list(): ResponseEntity<ListGroupResponse> {
-        TODO("동아리 목록 조회 API 구현")
+        val groups = groupService.list()
+        return ResponseEntity.ok(ListGroupResponse(groups))
     }
 
     @Operation(summary = "동아리 상세 조회", description = "동아리 상세 정보를 조회합니다")
     @GetMapping("/{groupId}")
     fun getById(@PathVariable groupId: Long): ResponseEntity<GroupDto> {
-        TODO("동아리 상세 조회 API 구현")
+        return ResponseEntity.ok(groupService.getById(groupId))
     }
 
     @Operation(summary = "동아리 정보 수정", description = "동아리 정보를 수정합니다")
@@ -57,18 +64,25 @@ class GroupController(
         @PathVariable groupId: Long,
         @RequestBody request: UpdateGroupRequest,
     ): ResponseEntity<GroupDto> {
-        TODO("동아리 정보 수정 API 구현")
+        val updatedGroup =
+            groupService.update(
+                groupId = groupId,
+                name = request.name,
+                detail = request.detail,
+            )
+        return ResponseEntity.ok(updatedGroup)
     }
 
     @Operation(summary = "동아리 삭제", description = "동아리를 삭제합니다")
     @DeleteMapping("/{groupId}")
     fun delete(@PathVariable groupId: Long): ResponseEntity<Unit> {
-        TODO("동아리 삭제 API 구현")
+        groupService.delete(groupId)
+        return ResponseEntity.noContent().build()
     }
 
     @Operation(summary = "초대 코드 재생성", description = "동아리 초대 코드를 재생성합니다")
     @PostMapping("/{groupId}/regenerate-code")
     fun regenerateCode(@PathVariable groupId: Long): ResponseEntity<GroupDto> {
-        TODO("초대 코드 재생성 API 구현")
+        return ResponseEntity.ok(groupService.regenerateCode(groupId))
     }
 }

--- a/src/main/kotlin/com/wafflestudio/spring2025/group/service/GroupService.kt
+++ b/src/main/kotlin/com/wafflestudio/spring2025/group/service/GroupService.kt
@@ -1,38 +1,119 @@
 package com.wafflestudio.spring2025.group.service
 
+import com.wafflestudio.spring2025.group.CreateBadGroupNameException
+import com.wafflestudio.spring2025.group.GroupCodeConflictException
+import com.wafflestudio.spring2025.group.GroupNameConflictException
+import com.wafflestudio.spring2025.group.GroupNotFoundException
 import com.wafflestudio.spring2025.group.dto.core.GroupDto
+import com.wafflestudio.spring2025.group.model.Group
 import com.wafflestudio.spring2025.group.repository.GroupRepository
+import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import kotlin.random.Random
 
 @Service
 class GroupService(
     private val groupRepository: GroupRepository,
 ) {
-    fun create(name: String, detail: String): GroupDto {
-        TODO("동아리 생성 (초대 코드 자동 생성) 구현")
+    @Transactional
+    fun create(name: String, detail: String?): GroupDto {
+        if (groupRepository.existsByName(name)) {
+            throw GroupNameConflictException()
+        }
+        if (name.length < 2) {
+            throw CreateBadGroupNameException()
+        }
+        if (name.all { it.isDigit() }) {
+            throw CreateBadGroupNameException()
+        }
+
+        val code = generateUniqueCode()
+        val group =
+            groupRepository.save(
+                Group(
+                    name = name,
+                    code = code,
+                    detail = detail ?: "동아리에 대한 설명이 없습니다.",
+                ),
+            )
+        return GroupDto(group)
     }
 
+    @Transactional(readOnly = true)
     fun getById(groupId: Long): GroupDto {
-        TODO("동아리 조회 구현")
+        val group = groupRepository.findByIdOrNull(groupId) ?: throw GroupNotFoundException()
+        return GroupDto(group)
     }
 
+    @Transactional(readOnly = true)
     fun getByCode(code: String): GroupDto {
-        TODO("초대 코드로 동아리 조회 구현")
+        val group = groupRepository.findByCode(code) ?: throw GroupNotFoundException()
+        return GroupDto(group)
     }
 
     fun list(): List<GroupDto> {
-        TODO("동아리 목록 조회 구현")
+        return groupRepository.findAll().take(5).map { GroupDto(it) }
     }
 
-    fun update(groupId: Long, name: String?, detail: String?): GroupDto {
-        TODO("동아리 정보 수정 구현")
+    @Transactional
+    fun update(groupId: Long,
+               name: String?,
+               detail: String?
+    ): GroupDto {
+        val group = groupRepository.findByIdOrNull(groupId) ?: throw GroupNotFoundException()
+
+        if (name != null) {
+            if (name.length < 2) {
+                throw CreateBadGroupNameException()
+            }
+            if (name.all { it.isDigit() }) {
+                throw CreateBadGroupNameException()
+            }
+            if (group.name != name && groupRepository.existsByName(name)) {
+                throw GroupNameConflictException()
+            }
+            group.name = name
+        }
+
+        if (detail != null) {
+            group.detail = detail
+        }
+
+        val savedGroup = groupRepository.save(group)
+        return GroupDto(savedGroup)
     }
 
+    @Transactional
     fun delete(groupId: Long) {
-        TODO("동아리 삭제 구현")
+        val group = groupRepository.findByIdOrNull(groupId) ?: throw GroupNotFoundException()
+        groupRepository.delete(group)
     }
 
+    @Transactional
     fun regenerateCode(groupId: Long): GroupDto {
-        TODO("초대 코드 재생성 구현")
+        val group = groupRepository.findByIdOrNull(groupId) ?: throw GroupNotFoundException()
+        group.code = generateUniqueCode(exclude = group.code)
+        val savedGroup = groupRepository.save(group)
+        return GroupDto(savedGroup)
+    }
+
+    private fun generateUniqueCode(exclude: String? = null): String {
+        repeat(20) {
+            val code = generateCode()
+            if (code != exclude && !groupRepository.existsByCode(code)) {
+                return code
+            }
+        }
+        throw GroupCodeConflictException()
+    }
+
+    private fun generateCode(): String {
+        val chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+        return buildString(6) {
+            repeat(6) {
+                append(chars[Random.nextInt(chars.length)])
+            }
+        }
     }
 }


### PR DESCRIPTION
- GroupController에 엔드포인트 연결
→ create/list/get/update/delete/regenerate-code 구현
- 그룹 이름 정책 반영
→ 두 글자 이상
→ 숫자로만 구성된 이름 금지
- 초대 코드 생성 방식 반영
→ 영어 대문자 + 숫자 6자리 조합, 중복 불가
- GroupService list 로직 수정
→ 최대 5개까지만 반환 없으면 그 이하의 개수를 반환