### PR TITLE
✨Registration에 pk 추가

### DIFF
--- a/src/main/kotlin/com/wafflestudio/spring2025/domain/registration/controller/RegistrationController.kt
+++ b/src/main/kotlin/com/wafflestudio/spring2025/domain/registration/controller/RegistrationController.kt
@@ -57,17 +57,32 @@ class RegistrationController(
         return ResponseEntity.ok(registrationService.getGuestsByEventId(eventId, userId))
     }
 
+    // 나중에 프론트에 요청에 따라 수정
+//    @Operation(
+//        summary = "이벤트 신청 단건 조회",
+//        description = "이벤트 신청 단건을 조회합니다.",
+//    )
+//    @GetMapping("/{registrationPublicId}")
+//    fun get(
+//        @PathVariable eventId: Long,
+//        @PathVariable registrationPublicId: String,
+//        @LoggedInUser user: User,
+//    ): ResponseEntity<RegistrationDto> {
+//        val userId = requireNotNull(user.id) { "로그인 사용자 ID가 없습니다." }
+//        return ResponseEntity.ok(registrationService.getByPublicId(eventId, registrationPublicId, userId))
+//    }
+//
 //    @Operation(
 //        summary = "이벤트 신청 취소",
 //        description = "취소 토큰을 이용해 신청을 취소합니다. 토큰은 24시간 내 만료되며, 취소 후 대기자가 자동 승격될 수 있습니다.",
 //    )
-//    @PostMapping("/{registrationId}/cancel")
+//    @PostMapping("/{registrationPublicId}/cancel")
 //    fun cancel(
 //        @PathVariable eventId: Long,
-//        @PathVariable registrationId: Long,
+//        @PathVariable registrationPublicId: String,
 //        @RequestParam token: String,
 //    ): ResponseEntity<Unit> {
-//        registrationService.cancelWithToken(registrationId, token)
+//        registrationService.cancelWithTokenByPublicId(eventId, registrationPublicId, token)
 //        return ResponseEntity.ok().build()
 //    }
 }

--- a/src/main/kotlin/com/wafflestudio/spring2025/domain/registration/dto/RegistrationGuestsResponse.kt
+++ b/src/main/kotlin/com/wafflestudio/spring2025/domain/registration/dto/RegistrationGuestsResponse.kt
@@ -16,8 +16,8 @@ data class RegistrationGuestsResponse(
 ) {
     @Schema(description = "참여자 정보")
     data class Guest(
-        @Schema(description = "신청 ID")
-        val id: Long,
+        @Schema(description = "신청 공개 ID")
+        val registrationPublicId: String,
         @Schema(description = "이름")
         val name: String,
         @Schema(description = "이메일 (관리자 요청 시 노출)")

--- a/src/main/kotlin/com/wafflestudio/spring2025/domain/registration/dto/core/RegistrationDto.kt
+++ b/src/main/kotlin/com/wafflestudio/spring2025/domain/registration/dto/core/RegistrationDto.kt
@@ -6,8 +6,8 @@ import io.swagger.v3.oas.annotations.media.Schema
 
 @Schema(description = "이벤트 신청 정보")
 data class RegistrationDto(
-    @Schema(description = "신청 ID")
-    val id: Long,
+    @Schema(description = "신청 공개 ID")
+    val registrationPublicId: String,
     @Schema(description = "사용자 ID")
     val userId: Long?,
     @Schema(description = "이벤트 ID")
@@ -22,7 +22,7 @@ data class RegistrationDto(
     val createdAt: Long,
 ) {
     constructor(registration: Registration) : this(
-        id = registration.id!!,
+        registrationPublicId = registration.registrationPublicId,
         userId = registration.userId,
         eventId = registration.eventId,
         guestName = registration.guestName,

--- a/src/main/kotlin/com/wafflestudio/spring2025/domain/registration/model/Registration.kt
+++ b/src/main/kotlin/com/wafflestudio/spring2025/domain/registration/model/Registration.kt
@@ -2,12 +2,16 @@ package com.wafflestudio.spring2025.domain.registration.model
 
 import org.springframework.data.annotation.CreatedDate
 import org.springframework.data.annotation.Id
+import org.springframework.data.relational.core.mapping.Column
 import org.springframework.data.relational.core.mapping.Table
 import java.time.Instant
+import java.util.UUID
 
 @Table("registrations")
 class Registration(
     @Id var id: Long? = null,
+    @Column("registration_public_id")
+    var registrationPublicId: String = UUID.randomUUID().toString(),
     var userId: Long? = null,
     var eventId: Long,
     var guestName: String? = null,

--- a/src/main/kotlin/com/wafflestudio/spring2025/domain/registration/repository/RegistrationRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/spring2025/domain/registration/repository/RegistrationRepository.kt
@@ -7,6 +7,8 @@ import org.springframework.data.repository.ListCrudRepository
 interface RegistrationRepository : ListCrudRepository<Registration, Long> {
     fun findByEventId(eventId: Long): List<Registration>
 
+    fun findByRegistrationPublicId(registrationPublicId: String): Registration?
+
     fun findByUserId(userId: Long): List<Registration>
 
     fun findByUserIdOrderByCreatedAtDesc(userId: Long): List<Registration>

--- a/src/main/resources/db/migration/V8__add_registration_public_id_to_registrations.sql
+++ b/src/main/resources/db/migration/V8__add_registration_public_id_to_registrations.sql
@@ -1,0 +1,12 @@
+ALTER TABLE registrations
+    ADD COLUMN registration_public_id VARCHAR(36) NULL;
+
+UPDATE registrations
+SET registration_public_id = UUID()
+WHERE registration_public_id IS NULL;
+
+ALTER TABLE registrations
+    MODIFY COLUMN registration_public_id VARCHAR(36) NOT NULL;
+
+ALTER TABLE registrations
+    ADD CONSTRAINT uk_registrations_public_id UNIQUE (registration_public_id);


### PR DESCRIPTION
DB 마이그레이션 추가: registrations에 registration_public_id (VARCHAR(36)) 컬럼 추가 → 기존 데이터 UUID로 채움 → NOT NULL + UNIQUE 제약 적용.
경로: src/main/resources/db/migration/V8__add_registration_public_id_to_registrations.sql

- 엔티티 수정: Registration에 registrationPublicId 필드 추가, 레코드 생성 시 자동 UUID 할당, 컬럼 매핑 추가.
경로: src/main/kotlin/com/wafflestudio/spring2025/domain/registration/model/Registration.kt
- 레포지토리 메서드 추가: registration_public_id로 조회 가능하도록 findByRegistrationPublicId 추가.
경로: src/main/kotlin/com/wafflestudio/spring2025/domain/registration/repository/RegistrationRepository.kt
- DTO 반환값 변경: 내부 id 대신 registrationPublicId 반환하도록 RegistrationDto, RegistrationGuestsResponse 수정.
경로: src/main/kotlin/com/wafflestudio/spring2025/domain/registration/dto/core/RegistrationDto.kt
경로: src/main/kotlin/com/wafflestudio/spring2025/domain/registration/dto/RegistrationGuestsResponse.kt 