### PR TITLE
:wrench: CORS 및 프록시 관련 설정 변경

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -62,4 +62,12 @@ management:
       show-details: always
 
 cors:
-  allowed-origins: http://localhost:3000,http://localhost:5173
+  allowed-origins: >
+    http://localhost:3000,
+    http://localhost:5173,
+    https://www.moiming.app,
+    https://moiming.app,
+    https://api.moiming.app
+
+server:
+  forward-headers-strategy: framework


### PR DESCRIPTION
CORS 허용 리스트에 프론트, 백엔드 도메인(Swagger 위해)을 추가하였으며, nginx에서 spring app으로 원래 요청의 프로토콜(https)이 전달되도록 하였습니다.