### PR TITLE
:bug: 이메일 인증코드 만료 이후 중복가입 오판 방지 및 중복가입 에러코드 세분화

### DIFF
--- a/src/main/kotlin/com/wafflestudio/spring2025/domain/auth/exception/AuthErrorCode.kt
+++ b/src/main/kotlin/com/wafflestudio/spring2025/domain/auth/exception/AuthErrorCode.kt
@@ -34,6 +34,11 @@ enum class AuthErrorCode(
         title = "유효하지 않은 인증 코드입니다.",
         message = "유효기간이 만료되었거나 잘못된 인증코드입니다.\n이메일 회원가입을 다시 시도해 주세요.",
     ),
+    EMAIL_VERIFICATION_PENDING(
+        httpStatusCode = HttpStatus.CONFLICT,
+        title = "이메일 인증 대기 중입니다.",
+        message = "이미 인증 메일이 발송되었습니다.\n메일함을 확인하여 인증을 완료해 주세요.",
+    ),
     EMAIL_ACCOUNT_ALREADY_EXIST(
         httpStatusCode = HttpStatus.CONFLICT,
         title = "이미 회원가입된 이메일입니다.",


### PR DESCRIPTION
이메일 인증코드 만료 후에 같은 이메일로 가입 시도 시 중복 가입 에러를 내려주는 오류가 있었는데 고쳤습니다. 더불어 '실제로 기 가입한 이메일계정이 있는 경우' vs '이메일 인증 미완료 상태인 경우'에 에러코드 및 에러메시지를 구별하였습니다.