### PR TITLE
🔧토큰 유저와 참여신청 유저가 불일치할 때 에러 내려주는 로직 추가

### DIFF
--- a/src/main/kotlin/com/wafflestudio/spring2025/domain/registration/controller/RegistrationController.kt
+++ b/src/main/kotlin/com/wafflestudio/spring2025/domain/registration/controller/RegistrationController.kt
@@ -52,10 +52,9 @@ class RegistrationController(
     @GetMapping
     fun getRegistrationInformation(
         @PathVariable registrationId: String,
-        @LoggedInUser user: User,
+        @LoggedInUser user: User?,
     ): ResponseEntity<GetRegistrationResponse> {
-        val userId = user.id ?: throw UserIdentityNotFoundException()
-        val response = registrationService.getRegistrationInformation(registrationId, userId)
+        val response = registrationService.getRegistrationInformation(registrationId, user)
         return ResponseEntity.ok(response)
     }
 }

--- a/src/main/kotlin/com/wafflestudio/spring2025/domain/registration/service/RegistrationService.kt
+++ b/src/main/kotlin/com/wafflestudio/spring2025/domain/registration/service/RegistrationService.kt
@@ -25,6 +25,7 @@ import com.wafflestudio.spring2025.domain.registration.model.RegistrationToken
 import com.wafflestudio.spring2025.domain.registration.model.RegistrationTokenPurpose
 import com.wafflestudio.spring2025.domain.registration.repository.RegistrationRepository
 import com.wafflestudio.spring2025.domain.registration.repository.RegistrationTokenRepository
+import com.wafflestudio.spring2025.domain.user.model.User
 import com.wafflestudio.spring2025.domain.user.repository.UserRepository
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -530,13 +531,17 @@ class RegistrationService(
 
     fun getRegistrationInformation(
         registrationId: String,
-        userId: Long,
+        user: User?,
     ): GetRegistrationResponse {
         val registration =
             registrationRepository.findByRegistrationPublicId(registrationId)
                 ?: throw RegistrationNotFoundException()
 
-        if (userId != registration.userId) throw RegistrationForbiddenException(RegistrationErrorCode.REGISTRATION_UNAUTHORIZED)
+        if (user != null &&
+            user.id != registration.userId
+        ) {
+            throw RegistrationForbiddenException(RegistrationErrorCode.REGISTRATION_UNAUTHORIZED)
+        }
 
         val status = registration.status
         val waitlistPosition =


### PR DESCRIPTION
- 준엽님이 요청하신 토큰 유저와 참여신청 유저가 불일치할 때 에러 내려주는 로직 추가
- 토큰이 null일 때는 그냥 통과(토큰있을 때만 작동하는 로직)