### PR TITLE
메일링 HTML 템플릿에 쓰이는 이미지를 svg에서 모두 png로 교체

### DIFF
--- a/src/main/resources/com/wafflestudio/spring2025/common/email/template/email-verification.html
+++ b/src/main/resources/com/wafflestudio/spring2025/common/email/template/email-verification.html
@@ -16,7 +16,7 @@
                 <table border="0" cellpadding="0" cellspacing="0" width="100%" style="margin-bottom: 30px;">
                     <tr>
                         <td>
-                            <img src="https://raw.githubusercontent.com/wafflestudio/moiming-web/refs/heads/main/public/moiming-logo.svg"
+                            <img src="https://raw.githubusercontent.com/wafflestudio/moiming-web/refs/heads/main/public/moiming-logo.png"
                                 alt="모이밍" width="120" style="display: block; border: 0;">
                         </td>
                     </tr>
@@ -30,17 +30,8 @@
                                 <table border="0" cellpadding="3" cellspacing="0" width="48" height="48">
                                     <tr>
                                         <td align="center" valign="middle" height="48" style="height: 48px;">
-                                            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
-                                                viewBox="0 0 24 24" fill="none" stroke="#E3F2FD" stroke-width="2"
-                                                stroke-linecap="round" stroke-linejoin="round"
-                                                class="lucide lucide-mail-question-mark-icon lucide-mail-question-mark">
-                                                <path
-                                                    d="M22 10.5V6a2 2 0 0 0-2-2H4a2 2 0 0 0-2 2v12c0 1.1.9 2 2 2h12.5" />
-                                                <path d="m22 7-8.97 5.7a1.94 1.94 0 0 1-2.06 0L2 7" />
-                                                <path
-                                                    d="M18 15.28c.2-.4.5-.8.9-1a2.1 2.1 0 0 1 2.6.4c.3.4.5.8.5 1.3 0 1.3-2 2-2 2" />
-                                                <path d="M20 22v.01" />
-                                            </svg>
+                                            <img src="https://raw.githubusercontent.com/wafflestudio/moiming-web/refs/heads/main/public/mail-question-mark-big.png"
+                                                 alt="mail-question-mark" width="20" style="display: block; border: 0; padding-bottom: 4px;">
                                         </td>
                                     </tr>
                                 </table>

--- a/src/main/resources/com/wafflestudio/spring2025/common/email/template/registration-banned.html
+++ b/src/main/resources/com/wafflestudio/spring2025/common/email/template/registration-banned.html
@@ -15,8 +15,8 @@
                 <table border="0" cellpadding="0" cellspacing="0" width="100%" style="margin-bottom: 30px;">
                     <tr>
                         <td>
-                            <img src="https://raw.githubusercontent.com/wafflestudio/moiming-web/refs/heads/main/public/moiming-logo.svg"
-                                alt="모이밍" width="120" style="display: block; border: 0;">
+                            <img src="https://raw.githubusercontent.com/wafflestudio/moiming-web/refs/heads/main/public/moiming-logo.png"
+                                 alt="모이밍" width="120" style="display: block; border: 0;">
                         </td>
                     </tr>
                 </table>
@@ -24,18 +24,12 @@
                 <table border="0" cellpadding="0" cellspacing="0" width="100%" style="margin-bottom: 30px;">
                     <tr>
                         <td width="48" style="vertical-align: middle;">
-                            <div
-                                style="width: 48px; height: 48px; background-color: #EC221F; border-radius: 50%; text-align: center;">
-                                <table border="0" cellpadding="3" cellspacing="0" width="48" height="48">
+                            <div style="width: 48px; height: 48px; background-color: #EC221F; border-radius: 50%;">
+                                <table border="0" cellpadding="0" cellspacing="0" width="48" height="48">
                                     <tr>
-                                        <td align="center" valign="middle" height="48" style="height: 48px;">
-                                            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
-                                                viewBox="0 0 24 24" fill="none" stroke="#E3F2FD" stroke-width="2"
-                                                stroke-linecap="round" stroke-linejoin="round"
-                                                class="lucide lucide-x-icon lucide-x">
-                                                <path d="M18 6 6 18" />
-                                                <path d="m6 6 12 12" />
-                                            </svg>
+                                        <td align="center" valign="middle" style="height: 48px; line-height: 0;">
+                                            <img src="https://raw.githubusercontent.com/wafflestudio/moiming-web/refs/heads/main/public/x.png"
+                                                 alt="x-mark" width="20" style="display: block; border: 0;">
                                         </td>
                                     </tr>
                                 </table>
@@ -57,14 +51,8 @@
                         style="font-size: 15px; color: #777; line-height: 1.6;">
                         <tr>
                             <td width="20" style="padding-bottom: 12px; vertical-align: middle;">
-                                <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24"
-                                    fill="none" stroke="#999" stroke-width="2" stroke-linecap="round"
-                                    stroke-linejoin="round" style="display: block;">
-                                    <path d="M8 2v4" />
-                                    <path d="M16 2v4" />
-                                    <rect width="18" height="18" x="3" y="4" rx="2" />
-                                    <path d="M3 10h18" />
-                                </svg>
+                                <img src="https://raw.githubusercontent.com/wafflestudio/moiming-web/refs/heads/main/public/calendar.png"
+                                     alt="calendar" width="20" style="display: block; border: 0;">
                             </td>
                             <td style="padding-bottom: 12px; padding-left: 10px; vertical-align: middle;">
                                 일시 <span style="margin-left:8px; color:#444;">{startsAt}-{endsAt}</span>
@@ -72,13 +60,8 @@
                         </tr>
                         <tr>
                             <td style="padding-bottom: 12px; vertical-align: middle;">
-                                <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24"
-                                    fill="none" stroke="#999" stroke-width="2" stroke-linecap="round"
-                                    stroke-linejoin="round" style="display: block;">
-                                    <path
-                                        d="M20 10c0 4.993-5.539 10.193-7.399 11.799a1 1 0 0 1-1.202 0C9.539 20.193 4 14.993 4 10a8 8 0 0 1 16 0" />
-                                    <circle cx="12" cy="10" r="3" />
-                                </svg>
+                                <img src="https://raw.githubusercontent.com/wafflestudio/moiming-web/refs/heads/main/public/map-pin.png"
+                                     alt="map-pin" width="20" style="display: block; border: 0;">
                             </td>
                             <td style="padding-bottom: 12px; padding-left: 10px; vertical-align: middle;">
                                 장소 <span style="margin-left:8px; color:#444;">{location}</span>
@@ -86,12 +69,8 @@
                         </tr>
                         <tr>
                             <td style="padding-bottom: 4px; vertical-align: middle;">
-                                <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24"
-                                    fill="none" stroke="#999" stroke-width="2" stroke-linecap="round"
-                                    stroke-linejoin="round" style="display: block;">
-                                    <path d="M19 21v-2a4 4 0 0 0-4-4H9a4 4 0 0 0-4 4v2" />
-                                    <circle cx="12" cy="7" r="4" />
-                                </svg>
+                                <img src="https://raw.githubusercontent.com/wafflestudio/moiming-web/refs/heads/main/public/user.png"
+                                     alt="user" width="20" style="display: block; border: 0;">
                             </td>
                             <td style="padding-bottom: 4px; padding-left: 10px; vertical-align: middle;">
                                 정원 <span style="margin-left:8px; color:#444;">{confirmedCount}/{capacity}명</span>
@@ -110,12 +89,8 @@
                             <table border="0" cellpadding="0" cellspacing="0">
                                 <tr>
                                     <td style="vertical-align: middle; padding-right: 8px;">
-                                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"
-                                            viewBox="0 0 24 24" fill="none" stroke="#666" stroke-width="2"
-                                            stroke-linecap="round" stroke-linejoin="round" style="display: block;">
-                                            <path d="M12 6v6l4 2" />
-                                            <circle cx="12" cy="12" r="10" />
-                                        </svg>
+                                        <img src="https://raw.githubusercontent.com/wafflestudio/moiming-web/refs/heads/main/public/clock.png"
+                                             alt="clock" width="20" style="display: block; border: 0;">
                                     </td>
                                     <td style="vertical-align: middle;">
                                         <strong style="font-weight: bold;">신청 기간:</strong>

--- a/src/main/resources/com/wafflestudio/spring2025/common/email/template/registration-canceled.html
+++ b/src/main/resources/com/wafflestudio/spring2025/common/email/template/registration-canceled.html
@@ -15,8 +15,8 @@
                 <table border="0" cellpadding="0" cellspacing="0" width="100%" style="margin-bottom: 30px;">
                     <tr>
                         <td>
-                            <img src="https://raw.githubusercontent.com/wafflestudio/moiming-web/refs/heads/main/public/moiming-logo.svg"
-                                alt="모이밍" width="120" style="display: block; border: 0;">
+                            <img src="https://raw.githubusercontent.com/wafflestudio/moiming-web/refs/heads/main/public/moiming-logo.png"
+                                 alt="모이밍" width="120" style="display: block; border: 0;">
                         </td>
                     </tr>
                 </table>
@@ -29,12 +29,8 @@
                                 <table border="0" cellpadding="3" cellspacing="0" width="48" height="48">
                                     <tr>
                                         <td align="center" valign="middle" height="48" style="height: 48px;">
-                                            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
-                                                viewBox="0 0 24 24" fill="none" stroke="#E3F2FD" stroke-width="2"
-                                                stroke-linecap="round" stroke-linejoin="round"
-                                                class="lucide lucide-check-icon lucide-check">
-                                                <path d="M20 6 9 17l-5-5" />
-                                            </svg>
+                                            <img src="https://raw.githubusercontent.com/wafflestudio/moiming-web/refs/heads/main/public/check.png"
+                                                 alt="check-mark" width="24" style="display: block; border: 0;">
                                         </td>
                                     </tr>
                                 </table>
@@ -56,14 +52,8 @@
                         style="font-size: 15px; color: #777; line-height: 1.6;">
                         <tr>
                             <td width="20" style="padding-bottom: 12px; vertical-align: middle;">
-                                <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24"
-                                    fill="none" stroke="#999" stroke-width="2" stroke-linecap="round"
-                                    stroke-linejoin="round" style="display: block;">
-                                    <path d="M8 2v4" />
-                                    <path d="M16 2v4" />
-                                    <rect width="18" height="18" x="3" y="4" rx="2" />
-                                    <path d="M3 10h18" />
-                                </svg>
+                                <img src="https://raw.githubusercontent.com/wafflestudio/moiming-web/refs/heads/main/public/calendar.png"
+                                     alt="calendar" width="20" style="display: block; border: 0;">
                             </td>
                             <td style="padding-bottom: 12px; padding-left: 10px; vertical-align: middle;">
                                 일시 <span style="margin-left:8px; color:#444;">{startsAt}-{endsAt}</span>
@@ -71,13 +61,8 @@
                         </tr>
                         <tr>
                             <td style="padding-bottom: 12px; vertical-align: middle;">
-                                <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24"
-                                    fill="none" stroke="#999" stroke-width="2" stroke-linecap="round"
-                                    stroke-linejoin="round" style="display: block;">
-                                    <path
-                                        d="M20 10c0 4.993-5.539 10.193-7.399 11.799a1 1 0 0 1-1.202 0C9.539 20.193 4 14.993 4 10a8 8 0 0 1 16 0" />
-                                    <circle cx="12" cy="10" r="3" />
-                                </svg>
+                                <img src="https://raw.githubusercontent.com/wafflestudio/moiming-web/refs/heads/main/public/map-pin.png"
+                                     alt="map-pin" width="20" style="display: block; border: 0;">
                             </td>
                             <td style="padding-bottom: 12px; padding-left: 10px; vertical-align: middle;">
                                 장소 <span style="margin-left:8px; color:#444;">{location}</span>
@@ -85,12 +70,8 @@
                         </tr>
                         <tr>
                             <td style="padding-bottom: 4px; vertical-align: middle;">
-                                <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24"
-                                    fill="none" stroke="#999" stroke-width="2" stroke-linecap="round"
-                                    stroke-linejoin="round" style="display: block;">
-                                    <path d="M19 21v-2a4 4 0 0 0-4-4H9a4 4 0 0 0-4 4v2" />
-                                    <circle cx="12" cy="7" r="4" />
-                                </svg>
+                                <img src="https://raw.githubusercontent.com/wafflestudio/moiming-web/refs/heads/main/public/user.png"
+                                     alt="user" width="20" style="display: block; border: 0;">
                             </td>
                             <td style="padding-bottom: 4px; padding-left: 10px; vertical-align: middle;">
                                 정원 <span style="margin-left:8px; color:#444;">{confirmedCount}/{capacity}명</span>
@@ -109,12 +90,8 @@
                             <table border="0" cellpadding="0" cellspacing="0">
                                 <tr>
                                     <td style="vertical-align: middle; padding-right: 8px;">
-                                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"
-                                            viewBox="0 0 24 24" fill="none" stroke="#666" stroke-width="2"
-                                            stroke-linecap="round" stroke-linejoin="round" style="display: block;">
-                                            <path d="M12 6v6l4 2" />
-                                            <circle cx="12" cy="12" r="10" />
-                                        </svg>
+                                        <img src="https://raw.githubusercontent.com/wafflestudio/moiming-web/refs/heads/main/public/clock.png"
+                                             alt="clock" width="20" style="display: block; border: 0;">
                                     </td>
                                     <td style="vertical-align: middle;">
                                         <strong style="font-weight: bold;">신청 기간:</strong>

--- a/src/main/resources/com/wafflestudio/spring2025/common/email/template/registration-confirmed.html
+++ b/src/main/resources/com/wafflestudio/spring2025/common/email/template/registration-confirmed.html
@@ -11,8 +11,8 @@
     <div style="width: 100%; max-width: 450px; margin: 0 auto; padding: 30px 20px; box-sizing: border-box;">
 
         <div style="margin-bottom: 30px;">
-            <img src="https://raw.githubusercontent.com/wafflestudio/moiming-web/refs/heads/main/public/moiming-logo.svg"
-                alt="모이밍" style="height: 32px; display: block; border: 0;">
+            <img src="https://raw.githubusercontent.com/wafflestudio/moiming-web/refs/heads/main/public/moiming-logo.png"
+                 alt="모이밍" width="120" style="display: block; border: 0;">
         </div>
 
         <table border="0" cellpadding="0" cellspacing="0" style="margin-bottom: 30px; width: 100%;">
@@ -23,11 +23,8 @@
                         <table border="0" cellpadding="3" cellspacing="0" width="48" height="48">
                             <tr>
                                 <td align="center" valign="middle" height="48" style="height: 48px;">
-                                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"
-                                        fill="none" stroke="#E3F2FD" stroke-width="2" stroke-linecap="round"
-                                        stroke-linejoin="round" class="lucide lucide-check-icon lucide-check">
-                                        <path d="M20 6 9 17l-5-5" />
-                                    </svg>
+                                    <img src="https://raw.githubusercontent.com/wafflestudio/moiming-web/refs/heads/main/public/check.png"
+                                         alt="check-mark" width="24" style="display: block; border: 0;">
                                 </td>
                             </tr>
                         </table>
@@ -47,14 +44,8 @@
                 style="width: 100%; font-size: 16px; color: #666; line-height: 1.6;">
                 <tr>
                     <td style="padding-bottom: 12px; vertical-align: middle; width: 20px;">
-                        <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none"
-                            stroke="#999" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
-                            style="display: block;">
-                            <path d="M8 2v4" />
-                            <path d="M16 2v4" />
-                            <rect width="18" height="18" x="3" y="4" rx="2" />
-                            <path d="M3 10h18" />
-                        </svg>
+                        <img src="https://raw.githubusercontent.com/wafflestudio/moiming-web/refs/heads/main/public/calendar.png"
+                             alt="calendar" width="18" style="display: block; border: 0;">
                     </td>
                     <td style="padding-bottom: 12px; padding-left: 10px; vertical-align: middle;">
                         일시 <span style="margin-left:8px; color:#444;">{startsAt}-{endsAt}</span>
@@ -62,13 +53,8 @@
                 </tr>
                 <tr>
                     <td style="padding-bottom: 12px; vertical-align: middle;">
-                        <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none"
-                            stroke="#999" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
-                            style="display: block;">
-                            <path
-                                d="M20 10c0 4.993-5.539 10.193-7.399 11.799a1 1 0 0 1-1.202 0C9.539 20.193 4 14.993 4 10a8 8 0 0 1 16 0" />
-                            <circle cx="12" cy="10" r="3" />
-                        </svg>
+                        <img src="https://raw.githubusercontent.com/wafflestudio/moiming-web/refs/heads/main/public/map-pin.png"
+                             alt="map-pin" width="18" style="display: block; border: 0;">
                     </td>
                     <td style="padding-bottom: 12px; padding-left: 10px; vertical-align: middle;">
                         장소 <span style="margin-left:8px; color:#444;">{location}</span>
@@ -76,12 +62,8 @@
                 </tr>
                 <tr>
                     <td style="padding-bottom: 4px; vertical-align: middle;">
-                        <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none"
-                            stroke="#999" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
-                            style="display: block;">
-                            <path d="M19 21v-2a4 4 0 0 0-4-4H9a4 4 0 0 0-4 4v2" />
-                            <circle cx="12" cy="7" r="4" />
-                        </svg>
+                        <img src="https://raw.githubusercontent.com/wafflestudio/moiming-web/refs/heads/main/public/user.png"
+                             alt="user" width="18" style="display: block; border: 0;">
                     </td>
                     <td style="padding-bottom: 4px; padding-left: 10px; vertical-align: middle;">
                         정원 <span style="margin-left:8px; color:#444;">{confirmedCount}/{capacity}명</span>
@@ -100,12 +82,8 @@
                     <table border="0" cellpadding="0" cellspacing="0">
                         <tr>
                             <td style="vertical-align: middle; padding-right: 8px;">
-                                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24"
-                                    fill="none" stroke="#666" stroke-width="2" stroke-linecap="round"
-                                    stroke-linejoin="round" style="display: block;">
-                                    <path d="M12 6v6l4 2" />
-                                    <circle cx="12" cy="12" r="10" />
-                                </svg>
+                                <img src="https://raw.githubusercontent.com/wafflestudio/moiming-web/refs/heads/main/public/clock.png"
+                                     alt="clock" width="20" style="display: block; border: 0;">
                             </td>
                             <td style="vertical-align: middle; line-height: 1;">
                                 <strong style="font-weight: bold;">신청 기간:</strong>

--- a/src/main/resources/com/wafflestudio/spring2025/common/email/template/registration-waitlist-promoted.html
+++ b/src/main/resources/com/wafflestudio/spring2025/common/email/template/registration-waitlist-promoted.html
@@ -11,8 +11,8 @@
     <div style="width: 100%; max-width: 450px; margin: 0 auto; padding: 30px 20px; box-sizing: border-box;">
 
         <div style="margin-bottom: 30px;">
-            <img src="https://raw.githubusercontent.com/wafflestudio/moiming-web/refs/heads/main/public/moiming-logo.svg"
-                alt="모이밍" style="height: 32px; display: block; border: 0;">
+            <img src="https://raw.githubusercontent.com/wafflestudio/moiming-web/refs/heads/main/public/moiming-logo.png"
+                 alt="모이밍" width="120" style="display: block; border: 0;">
         </div>
 
         <table border="0" cellpadding="0" cellspacing="0" style="margin-bottom: 30px; width: 100%;">
@@ -23,11 +23,8 @@
                         <table border="0" cellpadding="3" cellspacing="0" width="48" height="48">
                             <tr>
                                 <td align="center" valign="middle" height="48" style="height: 48px;">
-                                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"
-                                        fill="none" stroke="#E3F2FD" stroke-width="2" stroke-linecap="round"
-                                        stroke-linejoin="round" class="lucide lucide-check-icon lucide-check">
-                                        <path d="M20 6 9 17l-5-5" />
-                                    </svg>
+                                    <img src="https://raw.githubusercontent.com/wafflestudio/moiming-web/refs/heads/main/public/check.png"
+                                         alt="check-mark" width="20" style="display: block; border: 0;">
                                 </td>
                             </tr>
                         </table>
@@ -47,14 +44,8 @@
                 style="width: 100%; font-size: 15px; color: #777; line-height: 1.6;">
                 <tr>
                     <td width="20" style="padding-bottom: 12px; vertical-align: middle;">
-                        <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none"
-                            stroke="#999" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
-                            style="display: block;">
-                            <path d="M8 2v4" />
-                            <path d="M16 2v4" />
-                            <rect width="18" height="18" x="3" y="4" rx="2" />
-                            <path d="M3 10h18" />
-                        </svg>
+                        <img src="https://raw.githubusercontent.com/wafflestudio/moiming-web/refs/heads/main/public/calendar.png"
+                             alt="calendar" width="18" style="display: block; border: 0;">
                     </td>
                     <td style="padding-bottom: 12px; padding-left: 10px; vertical-align: middle;">
                         일시 <span style="margin-left:8px; color:#444;">{startsAt}~{endsAt}</span>
@@ -62,13 +53,8 @@
                 </tr>
                 <tr>
                     <td style="padding-bottom: 12px; vertical-align: middle;">
-                        <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none"
-                            stroke="#999" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
-                            style="display: block;">
-                            <path
-                                d="M20 10c0 4.993-5.539 10.193-7.399 11.799a1 1 0 0 1-1.202 0C9.539 20.193 4 14.993 4 10a8 8 0 0 1 16 0" />
-                            <circle cx="12" cy="10" r="3" />
-                        </svg>
+                        <img src="https://raw.githubusercontent.com/wafflestudio/moiming-web/refs/heads/main/public/map-pin.png"
+                             alt="map-pin" width="18" style="display: block; border: 0;">
                     </td>
                     <td style="padding-bottom: 12px; padding-left: 10px; vertical-align: middle;">
                         장소 <span style="margin-left:8px; color:#444;">{location}</span>
@@ -76,12 +62,8 @@
                 </tr>
                 <tr>
                     <td style="padding-bottom: 4px; vertical-align: middle;">
-                        <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none"
-                            stroke="#999" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
-                            style="display: block;">
-                            <path d="M19 21v-2a4 4 0 0 0-4-4H9a4 4 0 0 0-4 4v2" />
-                            <circle cx="12" cy="7" r="4" />
-                        </svg>
+                        <img src="https://raw.githubusercontent.com/wafflestudio/moiming-web/refs/heads/main/public/user.png"
+                             alt="user" width="18" style="display: block; border: 0;">
                     </td>
                     <td style="padding-bottom: 4px; padding-left: 10px; vertical-align: middle;">
                         정원 <span style="margin-left:8px; color:#444;">{confirmedCount}/{capacity}명</span>
@@ -100,12 +82,8 @@
                     <table border="0" cellpadding="0" cellspacing="0">
                         <tr>
                             <td style="vertical-align: middle; padding-right: 8px;">
-                                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24"
-                                    fill="none" stroke="#666" stroke-width="2" stroke-linecap="round"
-                                    stroke-linejoin="round" style="display: block;">
-                                    <path d="M12 6v6l4 2" />
-                                    <circle cx="12" cy="12" r="10" />
-                                </svg>
+                                <img src="https://raw.githubusercontent.com/wafflestudio/moiming-web/refs/heads/main/public/clock.png"
+                                     alt="clock" width="16" style="display: block; border: 0;">
                             </td>
                             <td style="vertical-align: middle;">
                                 <strong style="font-weight: bold;">신청 기간:</strong>

--- a/src/main/resources/com/wafflestudio/spring2025/common/email/template/registration-waitlisted.html
+++ b/src/main/resources/com/wafflestudio/spring2025/common/email/template/registration-waitlisted.html
@@ -15,8 +15,8 @@
                 <table border="0" cellpadding="0" cellspacing="0" width="100%" style="margin-bottom: 30px;">
                     <tr>
                         <td>
-                            <img src="https://raw.githubusercontent.com/wafflestudio/moiming-web/refs/heads/main/public/moiming-logo.svg"
-                                alt="모이밍" width="120" style="display: block; border: 0;">
+                            <img src="https://raw.githubusercontent.com/wafflestudio/moiming-web/refs/heads/main/public/moiming-logo.png"
+                                 alt="모이밍" width="120" style="display: block; border: 0;">
                         </td>
                     </tr>
                 </table>
@@ -29,20 +29,8 @@
                                 <table border="0" cellpadding="0" cellspacing="0" width="48" height="48">
                                     <tr>
                                         <td align="center" valign="middle" height="48" style="height: 48px;">
-                                            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
-                                                viewBox="0 0 24 24" fill="none" stroke="#E3F2FD" stroke-width="2"
-                                                stroke-linecap="round" stroke-linejoin="round"
-                                                class="lucide lucide-loader-icon lucide-loader"
-                                                style="display: inline-block; vertical-align: middle;">
-                                                <path d="M12 2v4" />
-                                                <path d="m16.2 7.8 2.9-2.9" />
-                                                <path d="M18 12h4" />
-                                                <path d="m16.2 16.2 2.9 2.9" />
-                                                <path d="M12 18v4" />
-                                                <path d="m4.9 19.1 2.9-2.9" />
-                                                <path d="M2 12h4" />
-                                                <path d="m4.9 4.9 2.9 2.9" />
-                                            </svg>
+                                            <img src="https://raw.githubusercontent.com/wafflestudio/moiming-web/refs/heads/main/public/loader.png"
+                                                 alt="loader-mark" width="20" style="display: block; border: 0;">
                                         </td>
                                     </tr>
                                 </table>
@@ -64,14 +52,8 @@
                         style="font-size: 15px; color: #777; line-height: 1.6;">
                         <tr>
                             <td width="20" style="padding-bottom: 12px; vertical-align: middle;">
-                                <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24"
-                                    fill="none" stroke="#999" stroke-width="2" stroke-linecap="round"
-                                    stroke-linejoin="round" style="display: block;">
-                                    <path d="M8 2v4" />
-                                    <path d="M16 2v4" />
-                                    <rect width="18" height="18" x="3" y="4" rx="2" />
-                                    <path d="M3 10h18" />
-                                </svg>
+                                <img src="https://raw.githubusercontent.com/wafflestudio/moiming-web/refs/heads/main/public/calendar.png"
+                                     alt="calendar" width="18" style="display: block; border: 0;">
                             </td>
                             <td style="padding-bottom: 12px; padding-left: 10px; vertical-align: middle;">
                                 일시 <span style="margin-left:8px; color:#444;">{startsAt}-{endsAt}</span>
@@ -79,13 +61,8 @@
                         </tr>
                         <tr>
                             <td style="padding-bottom: 12px; vertical-align: middle;">
-                                <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24"
-                                    fill="none" stroke="#999" stroke-width="2" stroke-linecap="round"
-                                    stroke-linejoin="round" style="display: block;">
-                                    <path
-                                        d="M20 10c0 4.993-5.539 10.193-7.399 11.799a1 1 0 0 1-1.202 0C9.539 20.193 4 14.993 4 10a8 8 0 0 1 16 0" />
-                                    <circle cx="12" cy="10" r="3" />
-                                </svg>
+                                <img src="https://raw.githubusercontent.com/wafflestudio/moiming-web/refs/heads/main/public/map-pin.png"
+                                     alt="map-pin" width="18" style="display: block; border: 0;">
                             </td>
                             <td style="padding-bottom: 12px; padding-left: 10px; vertical-align: middle;">
                                 장소 <span style="margin-left:8px; color:#444;">{location}</span>
@@ -93,12 +70,8 @@
                         </tr>
                         <tr>
                             <td style="padding-bottom: 4px; vertical-align: middle;">
-                                <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24"
-                                    fill="none" stroke="#999" stroke-width="2" stroke-linecap="round"
-                                    stroke-linejoin="round" style="display: block;">
-                                    <path d="M19 21v-2a4 4 0 0 0-4-4H9a4 4 0 0 0-4 4v2" />
-                                    <circle cx="12" cy="7" r="4" />
-                                </svg>
+                                <img src="https://raw.githubusercontent.com/wafflestudio/moiming-web/refs/heads/main/public/user.png"
+                                     alt="user" width="18" style="display: block; border: 0;">
                             </td>
                             <td style="padding-bottom: 4px; padding-left: 10px; vertical-align: middle;">
                                 정원 <span style="margin-left:8px; color:#444;">{confirmedCount}/{capacity}명</span>
@@ -117,12 +90,8 @@
                             <table border="0" cellpadding="0" cellspacing="0">
                                 <tr>
                                     <td style="vertical-align: middle; padding-right: 8px;">
-                                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"
-                                            viewBox="0 0 24 24" fill="none" stroke="#666" stroke-width="2"
-                                            stroke-linecap="round" stroke-linejoin="round" style="display: block;">
-                                            <path d="M12 6v6l4 2" />
-                                            <circle cx="12" cy="12" r="10" />
-                                        </svg>
+                                        <img src="https://raw.githubusercontent.com/wafflestudio/moiming-web/refs/heads/main/public/clock.png"
+                                             alt="clock" width="16" style="display: block; border: 0;">
                                     </td>
                                     <td style="vertical-align: middle;">
                                         <strong style="font-weight: bold;">신청 기간:</strong>


### PR DESCRIPTION
- 메일에서 svg가 작동 안해서
- 메일링 HTML 템플릿에 쓰이는 이미지를 svg에서 모두 png로 교체했습니다.