### PR TITLE
:bug: 만료된 토큰으로 로그아웃 시 오류 해결

### DIFF
--- a/src/main/kotlin/com/wafflestudio/spring2025/domain/auth/service/AuthService.kt
+++ b/src/main/kotlin/com/wafflestudio/spring2025/domain/auth/service/AuthService.kt
@@ -33,7 +33,7 @@ class AuthService(
     }
 
     fun logout(token: String?) {
-        if (token != null) {
+        if (token != null && jwtTokenProvider.validateToken(token)) {
             jwtBlacklistService.addToBlacklist(token)
         }
     }


### PR DESCRIPTION
jwtBlacklistService.addToBlacklist()에서 토큰 유효기한이 지났으면 에러를 던지는데 이를 처리하는 부분이 없어 internal server error가 발생하는 것을 확인하여, addToBlacklist() 함수에 진입하기 전 먼저 토큰 유효성 검사를 하도록 변경하였습니다.