### PR TITLE
🔧메일링 클라이언트를 AmazonSES로 교체하기 위한 코드 수정

### DIFF
--- a/src/main/kotlin/com/wafflestudio/spring2025/common/email/service/EmailService.kt
+++ b/src/main/kotlin/com/wafflestudio/spring2025/common/email/service/EmailService.kt
@@ -47,26 +47,6 @@ class EmailService(
         logger.info("Verification email sent to: $toEmail")
     }
 
-    /**
-     * Sends a welcome email after signup
-     */
-    fun sendWelcomeEmail(
-        toEmail: String,
-        nickname: String,
-    ) {
-        val htmlContent =
-            loadTemplate("welcome.html")
-                .replace("{nickname}", nickname)
-
-        sendHtmlEmail(
-            to = toEmail,
-            subject = "모이밍에 오신 것을 환영합니다!",
-            htmlContent = htmlContent,
-        )
-
-        logger.info("Welcome email sent to: $toEmail")
-    }
-
     private fun sendHtmlEmail(
         to: String,
         subject: String,

--- a/src/main/resources/com/wafflestudio/spring2025/common/email/template/welcome.html
+++ b/src/main/resources/com/wafflestudio/spring2025/common/email/template/welcome.html
@@ -1,7 +1,0 @@
-<!doctype html>
-<html lang="ko">
-  <body>
-    <h1>환영합니다, {nickname} 님!</h1>
-    <p>모이밍에 가입해 주셔서 감사합니다.</p>
-  </body>
-</html>


### PR DESCRIPTION
  - EmailService를 EmailClient 대신 JavaMailSender로 직접 발송하도록 변경
  - 공통 sendHtmlEmail() 추가, 예외 처리(MessagingException/MailException)와 로그 추가
  - 회원가입 환영 메일 sendWelcomeEmail() 추가
  - SES 샌드박스 모드 주의 주석 추가
  - 환영 메일 템플릿 welcome.html 생성
  - application.yaml에 SES SMTP 설정 + AWS 키/리전 플레이스홀더 추가
  - email.from-email을 no-reply@moiming.app로 설정