### PR TITLE
:bug: 대기자 목록 조회 오류 고침

### DIFF
--- a/src/main/kotlin/com/wafflestudio/spring2025/domain/registration/repository/RegistrationRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/spring2025/domain/registration/repository/RegistrationRepository.kt
@@ -144,11 +144,11 @@ interface RegistrationRepository :
 
     @Query(
         """
-        SELECT ranked.registration_public_id AS registrationPublicId,
-               ranked.waitlistNumber AS waitlistNumber
+        SELECT ranked.registration_public_id AS registration_public_id,
+               ranked.waitlist_number AS waitlist_number
         FROM (
             SELECT r.registration_public_id,
-                   ROW_NUMBER() OVER (ORDER BY r.created_at ASC, r.registration_public_id ASC) AS waitlistNumber
+                   ROW_NUMBER() OVER (ORDER BY r.created_at ASC, r.registration_public_id ASC) AS waitlist_number
             FROM registrations r
             WHERE r.event_id = :eventId AND r.status = :status
         ) ranked


### PR DESCRIPTION
Spring Data JDBC는 쿼리 결과로부터 snake_case 칼럼명을 기대하고 이를 알아서 camelCase 변수명으로 맵핑하는데, 쿼리 시 alias가 camelCase로 작성되어 JDBC가 기대한 snake_case 칼럼명이 없어서 오류가 발생한 것으로 파악하였습니다. 따라서 alias를 snake_case로 바꾸었습니다.