### PR TITLE
Ref/event domain

### DIFF
--- a/src/main/kotlin/com/wafflestudio/spring2025/domain/event/dto/request/CreateEventRequest.kt
+++ b/src/main/kotlin/com/wafflestudio/spring2025/domain/event/dto/request/CreateEventRequest.kt
@@ -22,7 +22,7 @@ data class CreateEventRequest(
     )
     val endsAt: Instant? = null,
     @Schema(description = "정원", example = "30")
-    val capacity: Int? = null,
+    val capacity: Int,
     @Schema(description = "대기 명단 사용 여부", example = "true")
     val waitlistEnabled: Boolean,
     @Schema(

--- a/src/main/kotlin/com/wafflestudio/spring2025/domain/event/dto/response/GuestPreview.kt
+++ b/src/main/kotlin/com/wafflestudio/spring2025/domain/event/dto/response/GuestPreview.kt
@@ -4,12 +4,12 @@ import io.swagger.v3.oas.annotations.media.Schema
 
 /**
  * 이벤트 참여자 미리보기 정보
- * (회원 참여자 기준)
+ * (회원/비회원 포함)
  */
 @Schema(description = "참여자 미리보기 정보")
 data class GuestPreview(
-    @Schema(description = "참여자 ID", example = "1")
-    val id: Long,
+    @Schema(description = "참여자 ID (비회원이면 null)", example = "1", nullable = true)
+    val id: Long?,
     @Schema(description = "참여자 이름", example = "홍길동")
     val name: String,
     @Schema(

--- a/src/main/kotlin/com/wafflestudio/spring2025/domain/event/exception/EventErrorCode.kt
+++ b/src/main/kotlin/com/wafflestudio/spring2025/domain/event/exception/EventErrorCode.kt
@@ -78,7 +78,7 @@ enum class EventErrorCode(
     REGISTRATION_TIME_RANGE_INVALID(
         httpStatusCode = HttpStatus.BAD_REQUEST,
         title = "신청 기간이 유효하지 않습니다.",
-        message = "신청 마감 시간이 모집 시작 시간보다\n빠를 수 없습니다.",
+        message = "신청 마감 시간이 신청 시작 시간보다\n빠를 수 없습니다.",
     ),
     REGISTRATION_STARTS_AFTER_EVENT_START(
         httpStatusCode = HttpStatus.BAD_REQUEST,

--- a/src/main/kotlin/com/wafflestudio/spring2025/domain/event/exception/EventErrorCode.kt
+++ b/src/main/kotlin/com/wafflestudio/spring2025/domain/event/exception/EventErrorCode.kt
@@ -28,46 +28,67 @@ enum class EventErrorCode(
     ),
 
     // 22xx - Validation / Bad Request
+    // 제목 검증
     EVENT_TITLE_BLANK(
         httpStatusCode = HttpStatus.BAD_REQUEST,
         title = "제목을 입력해 주세요.",
         message = "모임 제목은 비워둘 수 없습니다.",
     ),
 
-    EVENT_TIME_RANGE_INVALID(
+    // 정원 검증
+    EVENT_CAPACITY_REQUIRED(
         httpStatusCode = HttpStatus.BAD_REQUEST,
-        title = "모임 시각이 유효하지 않습니다.",
-        message = "종료 시각이 시작 시각보다\n빠를 수 없습니다.",
+        title = "정원을 입력해 주세요.",
+        message = "정원은 필수값입니다.",
     ),
-
     EVENT_CAPACITY_INVALID(
         httpStatusCode = HttpStatus.BAD_REQUEST,
         title = "정원이 유효하지 않습니다.",
         message = "정원은 1 이상이어야 합니다.",
     ),
 
-    REGISTRATION_ENDS_BEFORE_STARTS(
+    // 모임 시간 검증
+    EVENT_STARTS_IN_PAST(
         httpStatusCode = HttpStatus.BAD_REQUEST,
-        title = "모집 기간이 유효하지 않습니다.",
-        message = "모집 마감 시각이 모집 시작 시각보다\n빠를 수 없습니다.",
+        title = "모임 시작 시간이 유효하지 않습니다.",
+        message = "모임 시작 시간은\n현재 시간 이후여야 합니다.",
+    ),
+    EVENT_ENDS_IN_PAST(
+        httpStatusCode = HttpStatus.BAD_REQUEST,
+        title = "모임 종료 시간이 유효하지 않습니다.",
+        message = "모임 종료 시간은\n현재 시간 이후여야 합니다.",
+    ),
+    EVENT_TIME_RANGE_INVALID(
+        httpStatusCode = HttpStatus.BAD_REQUEST,
+        title = "모임 시간이 유효하지 않습니다.",
+        message = "모임 종료 시간이 모임 시작 시간보다\n빠를 수 없습니다.",
     ),
 
-    REGISTRATION_ENDS_AFTER_EVENT_START(
+    // 신청 기간 검증
+    REGISTRATION_STARTS_IN_PAST(
         httpStatusCode = HttpStatus.BAD_REQUEST,
-        title = "모집 기간이 유효하지 않습니다.",
-        message = "모집 마감 시각이 모임 시작 시각보다\n늦을 수 없습니다.",
+        title = "신청 시작 시간이 유효하지 않습니다.",
+        message = "신청 시작 시간은\n현재 시간 이후여야 합니다.",
     ),
-
+    REGISTRATION_ENDS_IN_PAST(
+        httpStatusCode = HttpStatus.BAD_REQUEST,
+        title = "신청 마감 시간이 유효하지 않습니다.",
+        message = "신청 마감 시간은\n현재 시간 이후여야 합니다.",
+    ),
+    REGISTRATION_TIME_RANGE_INVALID(
+        httpStatusCode = HttpStatus.BAD_REQUEST,
+        title = "신청 기간이 유효하지 않습니다.",
+        message = "신청 마감 시간이 모집 시작 시간보다\n빠를 수 없습니다.",
+    ),
     REGISTRATION_STARTS_AFTER_EVENT_START(
         httpStatusCode = HttpStatus.BAD_REQUEST,
-        title = "모집 기간이 유효하지 않습니다.",
-        message = "모집 시작 시각이 모임 시작 시각보다\n늦을 수 없습니다.",
+        title = "신청 기간이 유효하지 않습니다.",
+        message = "신청 시작 시간이 모임 시작 시간보다\n빨라야 합니다.",
     ),
-
-    EVENT_DEADLINE_PASSED(
+    REGISTRATION_ENDS_AFTER_EVENT_START(
         httpStatusCode = HttpStatus.BAD_REQUEST,
-        title = "모집이 마감되었습니다.",
-        message = "모집 마감 시각이 지나\n더 이상 신청할 수 없습니다.",
+        title = "신청 기간이 유효하지 않습니다.",
+        message = "신청 마감 시간이 모임 시작 시간보다\n빨라야 합니다.",
     ),
 
     // 23xx - Conflict

--- a/src/main/kotlin/com/wafflestudio/spring2025/domain/event/exception/EventException.kt
+++ b/src/main/kotlin/com/wafflestudio/spring2025/domain/event/exception/EventException.kt
@@ -19,8 +19,6 @@ class EventForbiddenException : EventException(error = EventErrorCode.NOT_EVENT_
 
 class EventFullException : EventException(error = EventErrorCode.EVENT_FULL)
 
-class EventDeadlinePassedException : EventException(error = EventErrorCode.EVENT_DEADLINE_PASSED)
-
 class EventValidationException(
     error: EventErrorCode,
 ) : EventException(error = error)

--- a/src/main/kotlin/com/wafflestudio/spring2025/domain/event/service/EventService.kt
+++ b/src/main/kotlin/com/wafflestudio/spring2025/domain/event/service/EventService.kt
@@ -356,38 +356,56 @@ class EventService(
         capacity: Int?,
         registrationStartsAt: Instant?,
         registrationEndsAt: Instant?,
+        now: Instant = Instant.now(),
     ) {
+        // 제목 검증
         if (title.isBlank()) {
             throw EventValidationException(EventErrorCode.EVENT_TITLE_BLANK)
         }
 
+        // 정원 검증
+        if (capacity == null) {
+            throw EventValidationException(EventErrorCode.EVENT_CAPACITY_REQUIRED)
+        }
+        if (capacity <= 0) {
+            throw EventValidationException(EventErrorCode.EVENT_CAPACITY_INVALID)
+        }
+
+        // 모임 시간 검증
+        if (startsAt != null && startsAt.isBefore(now)) {
+            throw EventValidationException(EventErrorCode.EVENT_STARTS_IN_PAST)
+        }
+        if (endsAt != null && endsAt.isBefore(now)) {
+            throw EventValidationException(EventErrorCode.EVENT_ENDS_IN_PAST)
+        }
         if (startsAt != null && endsAt != null && !startsAt.isBefore(endsAt)) {
             throw EventValidationException(EventErrorCode.EVENT_TIME_RANGE_INVALID)
         }
 
-        if (capacity != null && capacity <= 0) {
-            throw EventValidationException(EventErrorCode.EVENT_CAPACITY_INVALID)
+        // 신청 기간 검증
+        if (registrationStartsAt != null && registrationStartsAt.isBefore(now)) {
+            throw EventValidationException(EventErrorCode.REGISTRATION_STARTS_IN_PAST)
         }
-
+        if (registrationEndsAt != null && registrationEndsAt.isBefore(now)) {
+            throw EventValidationException(EventErrorCode.REGISTRATION_ENDS_IN_PAST)
+        }
         if (registrationStartsAt != null &&
             registrationEndsAt != null &&
             registrationStartsAt.isAfter(registrationEndsAt)
         ) {
-            throw EventValidationException(EventErrorCode.REGISTRATION_ENDS_BEFORE_STARTS)
+            throw EventValidationException(EventErrorCode.REGISTRATION_TIME_RANGE_INVALID)
         }
-
-        if (registrationEndsAt != null &&
-            startsAt != null &&
-            registrationEndsAt.isAfter(startsAt)
-        ) {
-            throw EventValidationException(EventErrorCode.REGISTRATION_ENDS_AFTER_EVENT_START)
-        }
-
         if (registrationStartsAt != null &&
             startsAt != null &&
             registrationStartsAt.isAfter(startsAt)
         ) {
             throw EventValidationException(EventErrorCode.REGISTRATION_STARTS_AFTER_EVENT_START)
+        }
+        if (registrationEndsAt != null &&
+            startsAt != null &&
+            registrationEndsAt.isAfter(startsAt)
+        ) {
+            throw EventValidationException(EventErrorCode.REGISTRATION_ENDS_AFTER_EVENT_START)
         }
     }
 

--- a/src/main/kotlin/com/wafflestudio/spring2025/domain/event/service/EventService.kt
+++ b/src/main/kotlin/com/wafflestudio/spring2025/domain/event/service/EventService.kt
@@ -179,20 +179,31 @@ class EventService(
                 registrationStatus = RegistrationStatus.CONFIRMED,
             )
 
+        val previewRegs = confirmedRegs.take(5)
+
         val previewUserIds =
-            confirmedRegs.mapNotNull { it.userId }.distinct().take(5)
+            previewRegs.mapNotNull { it.userId }.distinct()
 
         val usersById =
             userRepository.findAllById(previewUserIds).associateBy { it.id!! }
 
         val guestsPreview =
-            previewUserIds.mapNotNull { uid ->
-                usersById[uid]?.let {
+            previewRegs.mapNotNull { reg ->
+                val uid = reg.userId
+                if (uid == null) {
                     GuestPreview(
-                        id = it.id!!,
-                        name = it.name,
-                        profileImage = it.profileImage?.let { key -> imageService.presignedGetUrl(key) },
+                        id = null,
+                        name = reg.guestName ?: "참여자",
+                        profileImage = null,
                     )
+                } else {
+                    usersById[uid]?.let {
+                        GuestPreview(
+                            id = it.id!!,
+                            name = it.name,
+                            profileImage = it.profileImage?.let { key -> imageService.presignedGetUrl(key) },
+                        )
+                    }
                 }
             }
 


### PR DESCRIPTION
지금 보니 브랜치명을 잘못 만들었네요..(리팩토링이 아니고 버그 수정)

일정 생성 및 수정 시 검증 함수(ValidateCreateOrUpdate)에서 capacity가 not null이도록 수정했고, 일정 수정 시 현재 시간보다 과거로 변경할 수 있던 이슈를 해결했습니다. 추가로 전에 슬랙에 공유드린 것과 같이 (모집 -> 신청), (시각 -> 시간)으로 에러 메시지도 수정했습니다.

GuestPreview에서 비회원이 안내려가던 이유는 Confirmed된 회원을 가져온 후에 id가 null인 경우(비회원)에 대한 로직이 비어있었습니다. id가 null인 경우에는 name만 가져오고, id와 profileImage를 null로 내려주도록 코드 수정했습니다.