### PR TITLE
🔧확정자가 있을 시, 이벤트를 취소 못하게 하는 로직 추가

### DIFF
--- a/src/main/kotlin/com/wafflestudio/spring2025/domain/event/exception/EventErrorCode.kt
+++ b/src/main/kotlin/com/wafflestudio/spring2025/domain/event/exception/EventErrorCode.kt
@@ -97,4 +97,9 @@ enum class EventErrorCode(
         title = "정원이 초과되었습니다.",
         message = "모임 정원이 가득 차\n더 이상 신청할 수 없습니다.",
     ),
+    EVENT_HAS_CONFIRMED_REGISTRATIONS(
+        httpStatusCode = HttpStatus.CONFLICT,
+        title = "확정된 참가자가 있습니다.",
+        message = "확정된 참가자가 있는 모임은 삭제할 수 없습니다.",
+    ),
 }

--- a/src/main/kotlin/com/wafflestudio/spring2025/domain/event/exception/EventException.kt
+++ b/src/main/kotlin/com/wafflestudio/spring2025/domain/event/exception/EventException.kt
@@ -19,6 +19,8 @@ class EventForbiddenException : EventException(error = EventErrorCode.NOT_EVENT_
 
 class EventFullException : EventException(error = EventErrorCode.EVENT_FULL)
 
+class EventHasConfirmedRegistrationsException : EventException(error = EventErrorCode.EVENT_HAS_CONFIRMED_REGISTRATIONS)
+
 class EventValidationException(
     error: EventErrorCode,
 ) : EventException(error = error)

--- a/src/main/kotlin/com/wafflestudio/spring2025/domain/event/service/EventService.kt
+++ b/src/main/kotlin/com/wafflestudio/spring2025/domain/event/service/EventService.kt
@@ -12,6 +12,7 @@ import com.wafflestudio.spring2025.domain.event.dto.response.ViewerInfo
 import com.wafflestudio.spring2025.domain.event.dto.response.ViewerStatus
 import com.wafflestudio.spring2025.domain.event.exception.EventErrorCode
 import com.wafflestudio.spring2025.domain.event.exception.EventForbiddenException
+import com.wafflestudio.spring2025.domain.event.exception.EventHasConfirmedRegistrationsException
 import com.wafflestudio.spring2025.domain.event.exception.EventNotFoundException
 import com.wafflestudio.spring2025.domain.event.exception.EventValidationException
 import com.wafflestudio.spring2025.domain.event.model.Event
@@ -343,7 +344,18 @@ class EventService(
     ) {
         val event = getEventByPublicId(publicId)
         requireCreator(event, requesterId)
-        eventRepository.deleteById(requireNotNull(event.id))
+        val confirmedNumber =
+            registrationRepository
+                .countByEventIdAndStatus(
+                    eventID = requireNotNull(event.id),
+                    registrationStatus = RegistrationStatus.CONFIRMED,
+                ).toInt()
+
+        if (confirmedNumber > 0) {
+            throw EventHasConfirmedRegistrationsException()
+        } else {
+            eventRepository.deleteById(requireNotNull(event.id))
+        }
     }
 
     private fun getEventByPublicId(publicId: String): Event =


### PR DESCRIPTION
확정자가 있을 시, 이벤트를 취소 못시키는 로직을 추가했습니다.

- 409 Conflict
    - 확정자가 있는 상태에서 참여신청 취소를 하려고 하는 경우,
    
    {
        "code": "EVENT_HAS_CONFIRMED_REGISTRATIONS",
        "title": "확정된 참가자가 있습니다.",
        "message": "확정된 참가자가 있는 모임은 삭제할 수 없습니다."
     }

다음과 같은 에러를 내려줍니다.
