### PR TITLE
🔧메일링 제목 방식 변경

### DIFF
--- a/src/main/kotlin/com/wafflestudio/spring2025/common/email/service/EmailService.kt
+++ b/src/main/kotlin/com/wafflestudio/spring2025/common/email/service/EmailService.kt
@@ -138,7 +138,7 @@ class EmailService(
 
                 sendHtmlEmail(
                     to = data.toEmail,
-                    subject = "모이밍 참여 신청 확정",
+                    subject = emailName("참여 신청 확정", data.eventTitle),
                     htmlContent = htmlContent,
                 )
 
@@ -164,7 +164,7 @@ class EmailService(
 
                 sendHtmlEmail(
                     to = data.toEmail,
-                    subject = "모이밍 참여 신청 대기",
+                    subject = emailName("참여 신청 대기", data.eventTitle),
                     htmlContent = htmlContent,
                 )
 
@@ -186,7 +186,7 @@ class EmailService(
 
                 sendHtmlEmail(
                     to = data.toEmail,
-                    subject = "모이밍 참여 신청 강제 취소",
+                    subject = emailName("참여 신청 강제 취소", data.eventTitle),
                     htmlContent = htmlContent,
                 )
 
@@ -214,7 +214,7 @@ class EmailService(
 
         sendHtmlEmail(
             to = data.toEmail,
-            subject = "모이밍 참여 신청 취소",
+            subject = emailName("참여 신청 취소", data.eventTitle),
             htmlContent = htmlContent,
         )
 
@@ -255,7 +255,7 @@ class EmailService(
 
         sendHtmlEmail(
             to = toEmail,
-            subject = "모이밍 참여 신청 대기 후, 확정",
+            subject = emailName("참여 신청 대기 후 확정", eventTitle),
             htmlContent = htmlContent,
         )
 
@@ -273,6 +273,14 @@ class EmailService(
         } else {
             location
         }
+
+    private fun emailName(
+        title: String,
+        eventTitle: String?,
+    ): String {
+        val safeEventTitle = if (eventTitle.isNullOrBlank()) "제목 미정 모임" else eventTitle
+        return "[모이밍] $title: $safeEventTitle"
+    }
 
     private fun formatEventDateRange(
         start: Instant?,


### PR DESCRIPTION
메일링 제목을 합의한 [모이밍] 참여 신청 확정: {모임 제목} 로 만들었습니다.
emailName 함수를 통해 제목 포맷을 공통으로 처리했고 상태별 제목 문구는 우선 하드코딩으로 유지했습니다.
상태별 제목을 리스트/매핑으로 분리하는 방식도 시도했지만 복잡도 대비 이점이 크지 않아 현재는 단순한 형태로 두었습니다.