### PR TITLE
Bug/200 참여신청 동시성 이슈

### DIFF
--- a/src/main/kotlin/com/wafflestudio/spring2025/domain/registration/repository/RegistrationRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/spring2025/domain/registration/repository/RegistrationRepository.kt
@@ -46,6 +46,19 @@ interface RegistrationRepository :
         registrationStatus: RegistrationStatus,
     ): Long
 
+    @Query(
+        """
+        SELECT COUNT(*)
+        FROM registrations
+        WHERE event_id = :eventId AND status = :status
+        FOR SHARE
+        """,
+    )
+    fun countByEventIdAndStatusWithLock(
+        eventId: Long,
+        status: RegistrationStatus,
+    ): Long
+
     fun findByEventIdAndStatusOrderByCreatedAtAsc(
         eventID: Long,
         registrationStatus: RegistrationStatus,

--- a/src/main/kotlin/com/wafflestudio/spring2025/domain/registration/service/RegistrationService.kt
+++ b/src/main/kotlin/com/wafflestudio/spring2025/domain/registration/service/RegistrationService.kt
@@ -232,12 +232,20 @@ RegistrationService(
         guestEmail: String?,
         registrationPublicId: String,
     ) {
-        val registration =
+        // eventId를 얻기 위한 미리보기 조회 (락 없음)
+        val preview =
             registrationRepository.findByRegistrationPublicId(registrationPublicId)
                 ?: throw RegistrationNotFoundException()
 
+        // create()와 동일한 락 순서(event → registration)로 통일해 데드락 방지
+        eventLockRepository.lockById(preview.eventId)
         val event =
-            eventRepository.findById(registration.eventId).orElseThrow { EventNotFoundException() }
+            eventRepository.findById(preview.eventId).orElseThrow { EventNotFoundException() }
+
+        // event 락 획득 후 registration 행 락
+        val registration =
+            registrationRepository.lockByRegistrationPublicId(registrationPublicId)
+                ?: throw RegistrationNotFoundException()
 
         if (userId != null) {
             if (registration.userId != userId) {

--- a/src/main/kotlin/com/wafflestudio/spring2025/domain/registration/service/RegistrationService.kt
+++ b/src/main/kotlin/com/wafflestudio/spring2025/domain/registration/service/RegistrationService.kt
@@ -71,7 +71,7 @@ RegistrationService(
         val capacity = lockedEvent.capacity ?: throw IllegalStateException("이벤트의 capacity가 설정되어 있지 않습니다.")
         val currentConfirmed =
             registrationRepository
-                .countByEventIdAndStatus(eventPk, RegistrationStatus.CONFIRMED)
+                .countByEventIdAndStatusWithLock(eventPk, RegistrationStatus.CONFIRMED)
                 .toInt()
 
         val status =
@@ -677,7 +677,7 @@ RegistrationService(
 
         val capacity = event.capacity ?: throw IllegalStateException("이벤트의 capacity가 설정되어 있지 않습니다.")
         val confirmed =
-            registrationRepository.countByEventIdAndStatus(eventId, RegistrationStatus.CONFIRMED).toInt()
+            registrationRepository.countByEventIdAndStatusWithLock(eventId, RegistrationStatus.CONFIRMED).toInt()
         val available = capacity - confirmed
         if (available <= 0) return
 

--- a/src/test/kotlin/com/wafflestudio/spring2025/RegistrationIntegrationTest.kt
+++ b/src/test/kotlin/com/wafflestudio/spring2025/RegistrationIntegrationTest.kt
@@ -16,9 +16,6 @@ import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
-import java.util.concurrent.CountDownLatch
-import java.util.concurrent.Executors
-import java.util.concurrent.TimeUnit
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
@@ -37,6 +34,9 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import org.testcontainers.junit.jupiter.Testcontainers
 import java.time.Instant
 import java.util.UUID
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
 
 @SpringBootTest
 @ActiveProfiles("test")

--- a/src/test/kotlin/com/wafflestudio/spring2025/RegistrationIntegrationTest.kt
+++ b/src/test/kotlin/com/wafflestudio/spring2025/RegistrationIntegrationTest.kt
@@ -16,6 +16,9 @@ import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
@@ -350,6 +353,53 @@ class RegistrationIntegrationTest
             val hostParticipants = extractParticipants(hostResponse)
             assertTrue(hostParticipants.any { it.path("email").asText() == participant.email })
             assertTrue(hostParticipants.any { it.path("email").asText() == "guest@example.com" })
+        }
+
+        @Test
+        fun `동시에 여러 사용자가 신청해도 정원을 초과하지 않는다`() {
+            val capacity = 4
+            val totalUsers = 15
+
+            val (host, _) = dataGenerator.generateUser()
+            val event =
+                createEvent(
+                    createdBy = host.id!!,
+                    title = "동시성 테스트 이벤트",
+                    capacity = capacity,
+                    waitlistEnabled = true,
+                )
+
+            val tokens = (1..totalUsers).map { dataGenerator.generateUser().second }
+
+            val executor = Executors.newFixedThreadPool(totalUsers)
+            val startLatch = CountDownLatch(1)
+            val doneLatch = CountDownLatch(totalUsers)
+
+            tokens.forEach { token ->
+                executor.submit {
+                    try {
+                        startLatch.await()
+                        mvc.perform(
+                            post("/api/events/${event.publicId}/registrations")
+                                .header("Authorization", "Bearer $token")
+                                .content(mapper.writeValueAsString(CreateRegistrationRequest()))
+                                .contentType(MediaType.APPLICATION_JSON),
+                        )
+                    } finally {
+                        doneLatch.countDown()
+                    }
+                }
+            }
+
+            startLatch.countDown()
+            doneLatch.await(10, TimeUnit.SECONDS)
+            executor.shutdown()
+
+            val confirmed = registrationRepository.countByEventIdAndStatus(event.id!!, RegistrationStatus.CONFIRMED)
+            val waitlisted = registrationRepository.countByEventIdAndStatus(event.id!!, RegistrationStatus.WAITLISTED)
+
+            assertEquals(capacity.toLong(), confirmed, "CONFIRMED 수가 정원과 일치해야 합니다")
+            assertEquals((totalUsers - capacity).toLong(), waitlisted, "WAITLISTED 수가 정확해야 합니다")
         }
 
         private fun registerAsUser(

--- a/src/test/kotlin/com/wafflestudio/spring2025/RegistrationIntegrationTest.kt
+++ b/src/test/kotlin/com/wafflestudio/spring2025/RegistrationIntegrationTest.kt
@@ -34,6 +34,7 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import org.testcontainers.junit.jupiter.Testcontainers
 import java.time.Instant
 import java.util.UUID
+import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
@@ -374,17 +375,21 @@ class RegistrationIntegrationTest
             val executor = Executors.newFixedThreadPool(totalUsers)
             val startLatch = CountDownLatch(1)
             val doneLatch = CountDownLatch(totalUsers)
+            val statusCodes = CopyOnWriteArrayList<Int>()
 
             tokens.forEach { token ->
                 executor.submit {
                     try {
                         startLatch.await()
-                        mvc.perform(
-                            post("/api/events/${event.publicId}/registrations")
-                                .header("Authorization", "Bearer $token")
-                                .content(mapper.writeValueAsString(CreateRegistrationRequest()))
-                                .contentType(MediaType.APPLICATION_JSON),
-                        )
+                        val result =
+                            mvc
+                                .perform(
+                                    post("/api/events/${event.publicId}/registrations")
+                                        .header("Authorization", "Bearer $token")
+                                        .content(mapper.writeValueAsString(CreateRegistrationRequest()))
+                                        .contentType(MediaType.APPLICATION_JSON),
+                                ).andReturn()
+                        statusCodes.add(result.response.status)
                     } finally {
                         doneLatch.countDown()
                     }
@@ -392,8 +397,11 @@ class RegistrationIntegrationTest
             }
 
             startLatch.countDown()
-            doneLatch.await(10, TimeUnit.SECONDS)
+            val completed = doneLatch.await(10, TimeUnit.SECONDS)
             executor.shutdown()
+
+            assertTrue(completed, "모든 요청이 타임아웃(10초) 내에 완료되어야 합니다")
+            assertTrue(statusCodes.all { it == 200 }, "모든 요청이 HTTP 200으로 성공해야 합니다: $statusCodes")
 
             val confirmed = registrationRepository.countByEventIdAndStatus(event.id!!, RegistrationStatus.CONFIRMED)
             val waitlisted = registrationRepository.countByEventIdAndStatus(event.id!!, RegistrationStatus.WAITLISTED)


### PR DESCRIPTION
## ✨ Feature PR (to dev)

### 🧪 로컬 테스트 여부 (작업자 체크)
- [x] 로컬에서 Swagger 혹은 테스트 코드로 동작을 확인했습니다.

### 📄 documentation 최신화 여부
> 변경사항과 관련된 API의 swagger documentation이 실제 동작과 일치하는지 확인합니다.
- [ ] (작업자) 확인하였습니다.
- [ ] (리뷰어) 확인하였습니다.
확인했는데 registration 도메인에 documentation 안된 부분이 너무 많아서 지금 당장 해결하기엔 제가 여력이 안 됩니다.. 이번 사이클 지나가고 나서 어차피 yaml로 바꿀거라 그때 건드려볼 수 있을 것 같습니다.

### 📌 작업 내용(what & why)

- 참여자 수 count 시 lock을 획득한 후 읽도록 하였습니다 (FOR SHARE).
  - 기존의 일반 SELECT COUNT() 쿼리는 REPEATABLE_READ 격리 수준을 존중하기 위해 트랜잭션 시작 시점의 스냅샷을 기준으로 일관된 데이터를 읽습니다.
  - 즉, 트랜잭션이 시작되고 count가 실행되기 전에 참여자 수가 업데이트되었다면, 그것이 반영되지 않은 (스냅샷에 있는) 이전 값을 읽게 됩니다.
  - FOR SHARE를 붙임으로써 스냅샷이 아닌 현 시점의 데이터를 읽게 됩니다.
- 동시성 이슈를 테스트하는 integration test 케이스를 추가하였습니다.

### 🔎 영향 범위
  <!-- 해당하는 항목만 남기고 나머지는 삭제해주세요 -->                                                                                                                                                                                    
- 동시성 / 트랜잭션 처리 영향

### 🔥 관련 이슈
- closes #200
