### PR TITLE
Feat/202 event 생성수정 검증 로직 분리 및 시간 관련 정책 수정

### DIFF
--- a/src/main/kotlin/com/wafflestudio/spring2025/domain/event/dto/core/EventDto.kt
+++ b/src/main/kotlin/com/wafflestudio/spring2025/domain/event/dto/core/EventDto.kt
@@ -24,7 +24,7 @@ data class EventDto(
     @Schema(description = "신청 시작 시간 (epoch milliseconds)")
     val registrationStartsAt: Long?,
     @Schema(description = "신청 마감 시간 (epoch milliseconds)")
-    val registrationEndsAt: Long?,
+    val registrationEndsAt: Long,
     @Schema(description = "작성자 ID")
     val createdBy: Long,
     @Schema(description = "생성 일시 (epoch milliseconds)")
@@ -42,7 +42,7 @@ data class EventDto(
         capacity = event.capacity,
         waitlistEnabled = event.waitlistEnabled,
         registrationStartsAt = event.registrationStartsAt?.toEpochMilli(),
-        registrationEndsAt = event.registrationEndsAt?.toEpochMilli(),
+        registrationEndsAt = event.registrationEndsAt.toEpochMilli(),
         createdBy = event.createdBy,
         createdAt = event.createdAt?.toEpochMilli(),
         updatedAt = event.updatedAt?.toEpochMilli(),

--- a/src/main/kotlin/com/wafflestudio/spring2025/domain/event/dto/request/CreateEventRequest.kt
+++ b/src/main/kotlin/com/wafflestudio/spring2025/domain/event/dto/request/CreateEventRequest.kt
@@ -26,7 +26,7 @@ data class CreateEventRequest(
     @Schema(description = "대기 명단 사용 여부", example = "true")
     val waitlistEnabled: Boolean,
     @Schema(
-        description = "신청 시작 시간 (ISO-8601)",
+        description = "신청 시작 시간 (ISO-8601). null인 경우 요청 시점으로 자동 설정됩니다.",
         example = "2026-02-02T17:00:00Z",
     )
     val registrationStartsAt: Instant? = null,

--- a/src/main/kotlin/com/wafflestudio/spring2025/domain/event/dto/request/CreateEventRequest.kt
+++ b/src/main/kotlin/com/wafflestudio/spring2025/domain/event/dto/request/CreateEventRequest.kt
@@ -34,5 +34,5 @@ data class CreateEventRequest(
         description = "신청 마감 시간 (ISO-8601)",
         example = "2026-02-02T17:30:00Z",
     )
-    val registrationEndsAt: Instant? = null,
+    val registrationEndsAt: Instant,
 )

--- a/src/main/kotlin/com/wafflestudio/spring2025/domain/event/dto/response/EventDetailResponse.kt
+++ b/src/main/kotlin/com/wafflestudio/spring2025/domain/event/dto/response/EventDetailResponse.kt
@@ -37,8 +37,8 @@ data class EventInfo(
     val totalApplicants: Int,
     @Schema(description = "신청 시작 시간 (ISO-8601)", example = "2026-02-02T17:00:00Z", nullable = true)
     val registrationStartsAt: Instant?,
-    @Schema(description = "신청 마감 시간 (ISO-8601)", example = "2026-02-02T17:00:00Z", nullable = true)
-    val registrationEndsAt: Instant?,
+    @Schema(description = "신청 마감 시간 (ISO-8601)", example = "2026-02-02T17:00:00Z")
+    val registrationEndsAt: Instant,
 )
 
 @Schema(description = "생성자 정보 블록")

--- a/src/main/kotlin/com/wafflestudio/spring2025/domain/event/dto/response/MyEventsInfiniteResponse.kt
+++ b/src/main/kotlin/com/wafflestudio/spring2025/domain/event/dto/response/MyEventsInfiniteResponse.kt
@@ -14,7 +14,7 @@ data class MyEventResponse(
     val startsAt: Instant?,
     val endsAt: Instant?,
     val registrationStartsAt: Instant?,
-    val registrationEndsAt: Instant?,
+    val registrationEndsAt: Instant,
     val capacity: Int?,
     val totalApplicants: Int,
 )

--- a/src/main/kotlin/com/wafflestudio/spring2025/domain/event/dto/response/UpdateEventResponse.kt
+++ b/src/main/kotlin/com/wafflestudio/spring2025/domain/event/dto/response/UpdateEventResponse.kt
@@ -12,7 +12,7 @@ data class UpdateEventResponse(
     val capacity: Int?,
     val waitlistEnabled: Boolean,
     val registrationStartsAt: Instant?,
-    val registrationEndsAt: Instant?,
+    val registrationEndsAt: Instant,
 ) {
     companion object {
         fun from(event: Event): UpdateEventResponse =

--- a/src/main/kotlin/com/wafflestudio/spring2025/domain/event/exception/EventErrorCode.kt
+++ b/src/main/kotlin/com/wafflestudio/spring2025/domain/event/exception/EventErrorCode.kt
@@ -75,6 +75,11 @@ enum class EventErrorCode(
         title = "신청 기간이 유효하지 않습니다.",
         message = "신청 마감 시간이 모임 시작 시간보다\n빨라야 합니다.",
     ),
+    REGISTRATION_ENDS_AFTER_EVENT_END(
+        httpStatusCode = HttpStatus.BAD_REQUEST,
+        title = "신청 기간이 유효하지 않습니다.",
+        message = "신청 마감 시간이 모임 종료 시간보다\n빨라야 합니다.",
+    ),
 
     CAPACITY_CANNOT_DECREASE_WITH_PARTICIPANTS(
         httpStatusCode = HttpStatus.BAD_REQUEST,

--- a/src/main/kotlin/com/wafflestudio/spring2025/domain/event/exception/EventErrorCode.kt
+++ b/src/main/kotlin/com/wafflestudio/spring2025/domain/event/exception/EventErrorCode.kt
@@ -48,16 +48,6 @@ enum class EventErrorCode(
     ),
 
     // 모임 시간 검증
-    EVENT_STARTS_IN_PAST(
-        httpStatusCode = HttpStatus.BAD_REQUEST,
-        title = "모임 시작 시간이 유효하지 않습니다.",
-        message = "모임 시작 시간은\n현재 시간 이후여야 합니다.",
-    ),
-    EVENT_ENDS_IN_PAST(
-        httpStatusCode = HttpStatus.BAD_REQUEST,
-        title = "모임 종료 시간이 유효하지 않습니다.",
-        message = "모임 종료 시간은\n현재 시간 이후여야 합니다.",
-    ),
     EVENT_TIME_RANGE_INVALID(
         httpStatusCode = HttpStatus.BAD_REQUEST,
         title = "모임 시간이 유효하지 않습니다.",
@@ -65,11 +55,6 @@ enum class EventErrorCode(
     ),
 
     // 신청 기간 검증
-    REGISTRATION_STARTS_IN_PAST(
-        httpStatusCode = HttpStatus.BAD_REQUEST,
-        title = "신청 시작 시간이 유효하지 않습니다.",
-        message = "신청 시작 시간은\n현재 시간 이후여야 합니다.",
-    ),
     REGISTRATION_ENDS_IN_PAST(
         httpStatusCode = HttpStatus.BAD_REQUEST,
         title = "신청 마감 시간이 유효하지 않습니다.",
@@ -91,16 +76,6 @@ enum class EventErrorCode(
         message = "신청 마감 시간이 모임 시작 시간보다\n빨라야 합니다.",
     ),
 
-    REGISTRATION_START_CANNOT_DELAY_WITH_PARTICIPANTS(
-        httpStatusCode = HttpStatus.BAD_REQUEST,
-        title = "Registration start cannot be delayed.",
-        message = "When participants exist, registration start cannot be moved later than the current value.",
-    ),
-    REGISTRATION_END_CANNOT_ADVANCE_WITH_PARTICIPANTS(
-        httpStatusCode = HttpStatus.BAD_REQUEST,
-        title = "Registration end cannot be advanced.",
-        message = "When participants exist, registration end cannot be moved earlier than the current value.",
-    ),
     CAPACITY_CANNOT_DECREASE_WITH_PARTICIPANTS(
         httpStatusCode = HttpStatus.BAD_REQUEST,
         title = "Capacity cannot be decreased.",

--- a/src/main/kotlin/com/wafflestudio/spring2025/domain/event/model/Event.kt
+++ b/src/main/kotlin/com/wafflestudio/spring2025/domain/event/model/Event.kt
@@ -26,7 +26,7 @@ class Event(
     @Column("registration_starts_at")
     var registrationStartsAt: Instant? = null,
     @Column("registration_ends_at")
-    var registrationEndsAt: Instant? = null,
+    var registrationEndsAt: Instant,
     @Column("created_by")
     var createdBy: Long,
     @CreatedDate

--- a/src/main/kotlin/com/wafflestudio/spring2025/domain/event/service/EventService.kt
+++ b/src/main/kotlin/com/wafflestudio/spring2025/domain/event/service/EventService.kt
@@ -55,11 +55,12 @@ class EventService(
     ): String {
         val actualRegistrationStartsAt = registrationStartsAt ?: Instant.now()
 
-        validateCreateOrUpdate(
+        validateCreateConstraints(registrationEndsAt)
+        validateInvariantConstraints(
             title = title,
+            capacity = capacity,
             startsAt = startsAt,
             endsAt = endsAt,
-            capacity = capacity,
             registrationStartsAt = actualRegistrationStartsAt,
             registrationEndsAt = registrationEndsAt,
         )
@@ -325,35 +326,36 @@ class EventService(
         val previousCapacity = event.capacity
 
         val confirmedParticipants = countConfirmedParticipants(eventId)
-        validateParticipantAwareUpdate(
-            event = event,
-            registrationStartsAt = registrationStartsAt,
-            registrationEndsAt = registrationEndsAt,
+        validateCapacityUpdate(
             capacity = capacity,
             confirmedParticipants = confirmedParticipants,
         )
 
-        title?.let {
-            if (it.isBlank()) throw EventValidationException(EventErrorCode.EVENT_TITLE_BLANK)
-            event.title = it.trim()
-        }
+        val mergedTitle = title?.trim() ?: event.title
+        val mergedCapacity = capacity ?: event.capacity
+        val mergedStartsAt = startsAt ?: event.startsAt
+        val mergedEndsAt = endsAt ?: event.endsAt
+        val mergedRegistrationStartsAt = registrationStartsAt ?: event.registrationStartsAt
+        val mergedRegistrationEndsAt = registrationEndsAt ?: event.registrationEndsAt
+
+        validateInvariantConstraints(
+            title = mergedTitle,
+            capacity = mergedCapacity,
+            startsAt = mergedStartsAt,
+            endsAt = mergedEndsAt,
+            registrationStartsAt = mergedRegistrationStartsAt,
+            registrationEndsAt = mergedRegistrationEndsAt,
+        )
+
+        event.title = mergedTitle
         description?.let { event.description = it }
         location?.let { event.location = it }
-        startsAt?.let { event.startsAt = it }
-        endsAt?.let { event.endsAt = it }
-        capacity?.let { event.capacity = it }
+        event.startsAt = mergedStartsAt
+        event.endsAt = mergedEndsAt
+        event.capacity = mergedCapacity
         waitlistEnabled?.let { event.waitlistEnabled = it }
-        registrationStartsAt?.let { event.registrationStartsAt = it }
-        registrationEndsAt?.let { event.registrationEndsAt = it }
-
-        validateCreateOrUpdate(
-            title = event.title,
-            startsAt = event.startsAt,
-            endsAt = event.endsAt,
-            capacity = event.capacity,
-            registrationStartsAt = event.registrationStartsAt,
-            registrationEndsAt = event.registrationEndsAt,
-        )
+        event.registrationStartsAt = mergedRegistrationStartsAt
+        event.registrationEndsAt = mergedRegistrationEndsAt
 
         val savedEvent = eventRepository.save(event)
         if (isCapacityIncreased(previousCapacity, savedEvent.capacity)) {
@@ -395,14 +397,22 @@ class EventService(
         }
     }
 
-    private fun validateCreateOrUpdate(
+    private fun validateCreateConstraints(
+        registrationEndsAt: Instant,
+        now: Instant = Instant.now(),
+    ) {
+        if (registrationEndsAt.isBefore(now)) {
+            throw EventValidationException(EventErrorCode.REGISTRATION_ENDS_IN_PAST)
+        }
+    }
+
+    private fun validateInvariantConstraints(
         title: String,
+        capacity: Int?,
         startsAt: Instant?,
         endsAt: Instant?,
-        capacity: Int?,
         registrationStartsAt: Instant?,
-        registrationEndsAt: Instant?,
-        now: Instant = Instant.now(),
+        registrationEndsAt: Instant,
     ) {
         // 제목 검증
         if (title.isBlank()) {
@@ -417,40 +427,25 @@ class EventService(
             throw EventValidationException(EventErrorCode.EVENT_CAPACITY_INVALID)
         }
 
-        // 모임 시간 검증
-        if (startsAt != null && startsAt.isBefore(now)) {
-            throw EventValidationException(EventErrorCode.EVENT_STARTS_IN_PAST)
-        }
-        if (endsAt != null && endsAt.isBefore(now)) {
-            throw EventValidationException(EventErrorCode.EVENT_ENDS_IN_PAST)
-        }
-        if (startsAt != null && endsAt != null && !startsAt.isBefore(endsAt)) {
+        // 모임 시간 검증: 일정 시작 ≤ 일정 끝
+        if (startsAt != null && endsAt != null && startsAt.isAfter(endsAt)) {
             throw EventValidationException(EventErrorCode.EVENT_TIME_RANGE_INVALID)
         }
 
-        // 신청 기간 검증
-        if (registrationStartsAt != null && registrationStartsAt.isBefore(now)) {
-            throw EventValidationException(EventErrorCode.REGISTRATION_STARTS_IN_PAST)
-        }
-        if (registrationEndsAt != null && registrationEndsAt.isBefore(now)) {
-            throw EventValidationException(EventErrorCode.REGISTRATION_ENDS_IN_PAST)
-        }
-        if (registrationStartsAt != null &&
-            registrationEndsAt != null &&
-            registrationStartsAt.isAfter(registrationEndsAt)
-        ) {
+        // 신청 기간 검증: 모집 시작 < 모집 마감 (strict)
+        if (registrationStartsAt != null && !registrationStartsAt.isBefore(registrationEndsAt)) {
             throw EventValidationException(EventErrorCode.REGISTRATION_TIME_RANGE_INVALID)
         }
-        if (registrationStartsAt != null &&
-            startsAt != null &&
-            registrationStartsAt.isAfter(startsAt)
-        ) {
+        // 모집 시작 ≤ 일정 시작
+        if (registrationStartsAt != null && startsAt != null && registrationStartsAt.isAfter(startsAt)) {
             throw EventValidationException(EventErrorCode.REGISTRATION_STARTS_AFTER_EVENT_START)
         }
-        if (registrationEndsAt != null &&
-            startsAt != null &&
-            registrationEndsAt.isAfter(startsAt)
-        ) {
+        // 모집 마감 ≤ 일정 시작
+        if (startsAt != null && registrationEndsAt.isAfter(startsAt)) {
+            throw EventValidationException(EventErrorCode.REGISTRATION_ENDS_AFTER_EVENT_START)
+        }
+        // 모집 마감 ≤ 일정 끝 (행사시작 없을 때도 직접 체크)
+        if (endsAt != null && registrationEndsAt.isAfter(endsAt)) {
             throw EventValidationException(EventErrorCode.REGISTRATION_ENDS_AFTER_EVENT_START)
         }
     }
@@ -460,28 +455,11 @@ class EventService(
             .countByEventIdAndStatus(eventID = eventId, registrationStatus = RegistrationStatus.CONFIRMED)
             .toInt()
 
-    private fun validateParticipantAwareUpdate(
-        event: Event,
-        registrationStartsAt: Instant?,
-        registrationEndsAt: Instant?,
+    private fun validateCapacityUpdate(
         capacity: Int?,
         confirmedParticipants: Int,
-        now: Instant = Instant.now(),
     ) {
         if (confirmedParticipants <= 0) return
-
-        if (registrationStartsAt != null &&
-            event.registrationStartsAt != null &&
-            registrationStartsAt.isAfter(event.registrationStartsAt)
-        ) {
-            throw EventValidationException(EventErrorCode.REGISTRATION_START_CANNOT_DELAY_WITH_PARTICIPANTS)
-        }
-
-        if (registrationEndsAt != null &&
-            registrationEndsAt.isBefore(now)
-        ) {
-            throw EventValidationException(EventErrorCode.REGISTRATION_END_CANNOT_ADVANCE_WITH_PARTICIPANTS)
-        }
 
         if (capacity != null && capacity < confirmedParticipants) {
             throw EventValidationException(EventErrorCode.CAPACITY_CANNOT_DECREASE_WITH_PARTICIPANTS)
@@ -499,12 +477,12 @@ class EventService(
         confirmedCount: Int,
         waitlistEnabled: Boolean,
         registrationStartsAt: Instant?,
-        registrationEndsAt: Instant?,
+        registrationEndsAt: Instant,
         now: Instant = Instant.now(),
     ): CapabilitiesInfo {
         val withinWindow =
             (registrationStartsAt?.let { !now.isBefore(it) } ?: true) &&
-                (registrationEndsAt?.let { !now.isAfter(it) } ?: true)
+                !now.isAfter(registrationEndsAt)
 
         val isFull =
             capacity != null && confirmedCount >= capacity

--- a/src/main/kotlin/com/wafflestudio/spring2025/domain/event/service/EventService.kt
+++ b/src/main/kotlin/com/wafflestudio/spring2025/domain/event/service/EventService.kt
@@ -446,7 +446,7 @@ class EventService(
         }
         // 모집 마감 ≤ 일정 끝 (행사시작 없을 때도 직접 체크)
         if (endsAt != null && registrationEndsAt.isAfter(endsAt)) {
-            throw EventValidationException(EventErrorCode.REGISTRATION_ENDS_AFTER_EVENT_START)
+            throw EventValidationException(EventErrorCode.REGISTRATION_ENDS_AFTER_EVENT_END)
         }
     }
 

--- a/src/main/kotlin/com/wafflestudio/spring2025/domain/event/service/EventService.kt
+++ b/src/main/kotlin/com/wafflestudio/spring2025/domain/event/service/EventService.kt
@@ -50,15 +50,17 @@ class EventService(
         capacity: Int?,
         waitlistEnabled: Boolean,
         registrationStartsAt: Instant?,
-        registrationEndsAt: Instant?,
+        registrationEndsAt: Instant,
         createdBy: Long,
     ): String {
+        val actualRegistrationStartsAt = registrationStartsAt ?: Instant.now()
+
         validateCreateOrUpdate(
             title = title,
             startsAt = startsAt,
             endsAt = endsAt,
             capacity = capacity,
-            registrationStartsAt = registrationStartsAt,
+            registrationStartsAt = actualRegistrationStartsAt,
             registrationEndsAt = registrationEndsAt,
         )
 
@@ -72,7 +74,7 @@ class EventService(
                 endsAt = endsAt,
                 capacity = capacity,
                 waitlistEnabled = waitlistEnabled,
-                registrationStartsAt = registrationStartsAt,
+                registrationStartsAt = actualRegistrationStartsAt,
                 registrationEndsAt = registrationEndsAt,
                 createdBy = createdBy,
             )

--- a/src/main/kotlin/com/wafflestudio/spring2025/domain/registration/service/RegistrationService.kt
+++ b/src/main/kotlin/com/wafflestudio/spring2025/domain/registration/service/RegistrationService.kt
@@ -604,14 +604,9 @@ RegistrationService(
     }
 
     private fun isRegistrationEnabled(event: Event): Boolean {
-        val registrationStartsAt = event.registrationStartsAt
-        val registrationEndsAt = event.registrationEndsAt
         val now = Instant.now()
-
-        // null 정책: 시작/끝이 null이면 제한 없는 것으로 취급
-        val afterStart = registrationStartsAt?.let { !now.isBefore(it) } ?: true
-        val beforeEnd = registrationEndsAt?.let { !now.isAfter(it) } ?: true
-
+        val afterStart = event.registrationStartsAt?.let { !now.isBefore(it) } ?: true
+        val beforeEnd = !now.isAfter(event.registrationEndsAt)
         return afterStart && beforeEnd
     }
 

--- a/src/main/resources/db/migration/V14__make_registration_ends_at_not_null.sql
+++ b/src/main/resources/db/migration/V14__make_registration_ends_at_not_null.sql
@@ -1,1 +1,2 @@
+DELETE FROM events WHERE registration_ends_at IS NULL;
 ALTER TABLE events MODIFY registration_ends_at DATETIME(6) NOT NULL;

--- a/src/main/resources/db/migration/V14__make_registration_ends_at_not_null.sql
+++ b/src/main/resources/db/migration/V14__make_registration_ends_at_not_null.sql
@@ -1,2 +1,3 @@
+DELETE r FROM registrations r INNER JOIN events e ON r.event_id = e.id WHERE e.registration_ends_at IS NULL;
 DELETE FROM events WHERE registration_ends_at IS NULL;
 ALTER TABLE events MODIFY registration_ends_at DATETIME(6) NOT NULL;

--- a/src/main/resources/db/migration/V14__make_registration_ends_at_not_null.sql
+++ b/src/main/resources/db/migration/V14__make_registration_ends_at_not_null.sql
@@ -1,0 +1,1 @@
+ALTER TABLE events MODIFY registration_ends_at DATETIME(6) NOT NULL;

--- a/src/test/kotlin/com/wafflestudio/spring2025/EventIntegrationTest.kt
+++ b/src/test/kotlin/com/wafflestudio/spring2025/EventIntegrationTest.kt
@@ -58,7 +58,7 @@ class EventIntegrationTest
             startsAt: Instant = Instant.now().plusSeconds(3600),
             endsAt: Instant = Instant.now().plusSeconds(7200),
             registrationStartsAt: Instant? = null,
-            registrationEndsAt: Instant? = null,
+            registrationEndsAt: Instant = Instant.now().plusSeconds(5400),
         ): Event =
             eventRepository.save(
                 Event(
@@ -177,6 +177,7 @@ class EventIntegrationTest
                     waitlistEnabled = false,
                     startsAt = Instant.now().minusSeconds(3600),
                     endsAt = Instant.now().plusSeconds(3600),
+                    registrationEndsAt = Instant.now().plusSeconds(5400),
                 )
 
             mvc
@@ -199,6 +200,7 @@ class EventIntegrationTest
                     waitlistEnabled = false,
                     startsAt = null,
                     endsAt = Instant.now().minusSeconds(3600),
+                    registrationEndsAt = Instant.now().plusSeconds(5400),
                 )
 
             mvc
@@ -221,6 +223,7 @@ class EventIntegrationTest
                     waitlistEnabled = false,
                     startsAt = Instant.now().plusSeconds(7200),
                     endsAt = Instant.now().plusSeconds(3600), // startsAt 보다 이전
+                    registrationEndsAt = Instant.now().plusSeconds(5400),
                 )
 
             mvc
@@ -242,6 +245,7 @@ class EventIntegrationTest
                     capacity = 10,
                     waitlistEnabled = false,
                     registrationStartsAt = Instant.now().minusSeconds(3600),
+                    registrationEndsAt = Instant.now().plusSeconds(5400),
                 )
 
             mvc
@@ -309,6 +313,7 @@ class EventIntegrationTest
                     startsAt = Instant.now().plusSeconds(3600),
                     endsAt = Instant.now().plusSeconds(7200),
                     registrationStartsAt = Instant.now().plusSeconds(5400),
+                    registrationEndsAt = Instant.now().plusSeconds(7200),
                 )
 
             mvc

--- a/src/test/kotlin/com/wafflestudio/spring2025/EventIntegrationTest.kt
+++ b/src/test/kotlin/com/wafflestudio/spring2025/EventIntegrationTest.kt
@@ -55,8 +55,8 @@ class EventIntegrationTest
             title: String = "테스트 이벤트",
             capacity: Int = 10,
             waitlistEnabled: Boolean = false,
-            startsAt: Instant = Instant.now().plusSeconds(3600),
-            endsAt: Instant = Instant.now().plusSeconds(7200),
+            startsAt: Instant = Instant.now().plusSeconds(7200),
+            endsAt: Instant = Instant.now().plusSeconds(10800),
             registrationStartsAt: Instant? = null,
             registrationEndsAt: Instant = Instant.now().plusSeconds(5400),
         ): Event =
@@ -170,14 +170,14 @@ class EventIntegrationTest
         @Test
         fun `모임 시작 시간이 신청 마감 시간보다 이르면 이벤트 생성 요청 시 400을 반환한다`() {
             val (_, token) = dataGenerator.generateUser()
-            // startsAt=now-3600 이면 registrationEndsAt(+5400) > startsAt(-3600) 위반
+            // registrationEndsAt(+5400) > startsAt(+3600) 위반
             val request =
                 CreateEventRequest(
                     title = "정기 모임",
                     capacity = 10,
                     waitlistEnabled = false,
-                    startsAt = Instant.now().minusSeconds(3600),
-                    endsAt = Instant.now().plusSeconds(3600),
+                    startsAt = Instant.now().plusSeconds(3600),
+                    endsAt = Instant.now().plusSeconds(7200),
                     registrationEndsAt = Instant.now().plusSeconds(5400),
                 )
 

--- a/src/test/kotlin/com/wafflestudio/spring2025/EventIntegrationTest.kt
+++ b/src/test/kotlin/com/wafflestudio/spring2025/EventIntegrationTest.kt
@@ -168,8 +168,9 @@ class EventIntegrationTest
         }
 
         @Test
-        fun `모임 시작 시간이 과거이면 이벤트 생성 요청 시 400을 반환한다`() {
+        fun `모임 시작 시간이 신청 마감 시간보다 이르면 이벤트 생성 요청 시 400을 반환한다`() {
             val (_, token) = dataGenerator.generateUser()
+            // startsAt=now-3600 이면 registrationEndsAt(+5400) > startsAt(-3600) 위반
             val request =
                 CreateEventRequest(
                     title = "정기 모임",
@@ -187,30 +188,7 @@ class EventIntegrationTest
                         .content(mapper.writeValueAsString(request))
                         .contentType(MediaType.APPLICATION_JSON),
                 ).andExpect(status().isBadRequest)
-                .andExpect(jsonPath("$.code").value("EVENT_STARTS_IN_PAST"))
-        }
-
-        @Test
-        fun `모임 종료 시간이 과거이면 이벤트 생성 요청 시 400을 반환한다`() {
-            val (_, token) = dataGenerator.generateUser()
-            val request =
-                CreateEventRequest(
-                    title = "정기 모임",
-                    capacity = 10,
-                    waitlistEnabled = false,
-                    startsAt = null,
-                    endsAt = Instant.now().minusSeconds(3600),
-                    registrationEndsAt = Instant.now().plusSeconds(5400),
-                )
-
-            mvc
-                .perform(
-                    post("/api/events")
-                        .header("Authorization", "Bearer $token")
-                        .content(mapper.writeValueAsString(request))
-                        .contentType(MediaType.APPLICATION_JSON),
-                ).andExpect(status().isBadRequest)
-                .andExpect(jsonPath("$.code").value("EVENT_ENDS_IN_PAST"))
+                .andExpect(jsonPath("$.code").value("REGISTRATION_ENDS_AFTER_EVENT_START"))
         }
 
         @Test
@@ -237,8 +215,9 @@ class EventIntegrationTest
         }
 
         @Test
-        fun `신청 시작 시간이 과거이면 이벤트 생성 요청 시 400을 반환한다`() {
+        fun `신청 시작 시간이 과거여도 이벤트를 생성할 수 있다`() {
             val (_, token) = dataGenerator.generateUser()
+            // 과거 registrationStartsAt = 이미 모집이 시작된 것으로 허용
             val request =
                 CreateEventRequest(
                     title = "정기 모임",
@@ -254,8 +233,7 @@ class EventIntegrationTest
                         .header("Authorization", "Bearer $token")
                         .content(mapper.writeValueAsString(request))
                         .contentType(MediaType.APPLICATION_JSON),
-                ).andExpect(status().isBadRequest)
-                .andExpect(jsonPath("$.code").value("REGISTRATION_STARTS_IN_PAST"))
+                ).andExpect(status().isOk)
         }
 
         @Test
@@ -825,8 +803,9 @@ class EventIntegrationTest
         }
 
         @Test
-        fun `모임 시작 시간을 과거로 수정 요청 시 400을 반환한다`() {
+        fun `모임 시작 시간을 신청 마감 시간보다 이전으로 수정하면 400을 반환한다`() {
             val (user, token) = dataGenerator.generateUser()
+            // 기본 registrationEndsAt=now+5400 → startsAt=now-3600 으로 변경하면 역전
             val event = createEventInDb(createdBy = user.id!!)
 
             mvc
@@ -836,7 +815,7 @@ class EventIntegrationTest
                         .content(mapper.writeValueAsString(UpdateEventRequest(startsAt = Instant.now().minusSeconds(3600))))
                         .contentType(MediaType.APPLICATION_JSON),
                 ).andExpect(status().isBadRequest)
-                .andExpect(jsonPath("$.code").value("EVENT_STARTS_IN_PAST"))
+                .andExpect(jsonPath("$.code").value("REGISTRATION_ENDS_AFTER_EVENT_START"))
         }
 
         @Test
@@ -880,7 +859,7 @@ class EventIntegrationTest
         }
 
         @Test
-        fun `확정 참가자 있을 때 신청 시작 시간을 늦추면 400을 반환한다`() {
+        fun `확정 참가자 있어도 신청 시작 시간을 늦출 수 있다`() {
             val (host, token) = dataGenerator.generateUser()
             val (participant, _) = dataGenerator.generateUser()
             val event =
@@ -900,15 +879,14 @@ class EventIntegrationTest
                 .perform(
                     put("/api/events/${event.publicId}")
                         .header("Authorization", "Bearer $token")
-                        // +3600 → +4500 으로 늦춤 (기존 값보다 이후, startsAt=+7200 이전)
+                        // +3600 → +4500 으로 늦춤 — 기존 신청자 영향 없이 모집 중단
                         .content(mapper.writeValueAsString(UpdateEventRequest(registrationStartsAt = Instant.now().plusSeconds(4500))))
                         .contentType(MediaType.APPLICATION_JSON),
-                ).andExpect(status().isBadRequest)
-                .andExpect(jsonPath("$.code").value("REGISTRATION_START_CANNOT_DELAY_WITH_PARTICIPANTS"))
+                ).andExpect(status().isOk)
         }
 
         @Test
-        fun `확정 참가자 있을 때 신청 마감 시간을 현재 시각 이전으로 변경하면 400을 반환한다`() {
+        fun `확정 참가자 있어도 신청 마감 시간을 과거로 앞당길 수 있다`() {
             val (host, token) = dataGenerator.generateUser()
             val (participant, _) = dataGenerator.generateUser()
             val event = createEventInDb(createdBy = host.id!!, registrationEndsAt = Instant.now().plusSeconds(3600))
@@ -921,10 +899,47 @@ class EventIntegrationTest
                 .perform(
                     put("/api/events/${event.publicId}")
                         .header("Authorization", "Bearer $token")
+                        // 모집 마감을 현재 이전으로 앞당김 — 모집 중단, 기존 신청자 영향 없음
                         .content(mapper.writeValueAsString(UpdateEventRequest(registrationEndsAt = Instant.now().minusSeconds(60))))
                         .contentType(MediaType.APPLICATION_JSON),
+                ).andExpect(status().isOk)
+        }
+
+        @Test
+        fun `신청 시작 시간과 신청 마감 시간이 같으면 400을 반환한다`() {
+            val (_, token) = dataGenerator.generateUser()
+            val sameTime = Instant.now().plusSeconds(3600)
+            val request =
+                CreateEventRequest(
+                    title = "정기 모임",
+                    capacity = 10,
+                    waitlistEnabled = false,
+                    registrationStartsAt = sameTime,
+                    registrationEndsAt = sameTime,
+                )
+
+            mvc
+                .perform(
+                    post("/api/events")
+                        .header("Authorization", "Bearer $token")
+                        .content(mapper.writeValueAsString(request))
+                        .contentType(MediaType.APPLICATION_JSON),
                 ).andExpect(status().isBadRequest)
-                .andExpect(jsonPath("$.code").value("REGISTRATION_END_CANNOT_ADVANCE_WITH_PARTICIPANTS"))
+                .andExpect(jsonPath("$.code").value("REGISTRATION_TIME_RANGE_INVALID"))
+        }
+
+        @Test
+        fun `일정 수정 시 신청 마감 시간을 과거로 앞당길 수 있다`() {
+            val (user, token) = dataGenerator.generateUser()
+            val event = createEventInDb(createdBy = user.id!!, registrationEndsAt = Instant.now().plusSeconds(3600))
+
+            mvc
+                .perform(
+                    put("/api/events/${event.publicId}")
+                        .header("Authorization", "Bearer $token")
+                        .content(mapper.writeValueAsString(UpdateEventRequest(registrationEndsAt = Instant.now().minusSeconds(60))))
+                        .contentType(MediaType.APPLICATION_JSON),
+                ).andExpect(status().isOk)
         }
 
         @Test

--- a/src/test/kotlin/com/wafflestudio/spring2025/RegistrationIntegrationTest.kt
+++ b/src/test/kotlin/com/wafflestudio/spring2025/RegistrationIntegrationTest.kt
@@ -415,7 +415,7 @@ class RegistrationIntegrationTest
             capacity: Int = 10,
             waitlistEnabled: Boolean = false,
             registrationStartsAt: Instant? = null,
-            registrationEndsAt: Instant? = null,
+            registrationEndsAt: Instant = Instant.now().plusSeconds(5400),
         ): Event =
             eventRepository.save(
                 Event(


### PR DESCRIPTION
## ✨ Feature PR (to dev)

### 🧪 로컬 테스트 여부 (작업자 체크)
- [x] 로컬에서 Swagger 혹은 테스트 코드로 동작을 확인했습니다.

### 📄 documentation 최신화 여부
> 변경사항과 관련된 API의 swagger documentation이 실제 동작과 일치하는지 확인합니다.
- [x] (작업자) 확인하였습니다.
- [ ] (리뷰어) 확인하였습니다.

### 📌 작업 내용(what & why)
- '모집 마감' not null 처리: 프론트에서도 null이 아니도록 강제하고 있는데 굳이 null 검사할 필요가 없기 때문
  - [API 변동] events -> 'registrationEndsAt' not null
  - [DB schema 변동] POST /events -> 'registrationEndsAt' not null
- 시간 관계에 관한 로직 최신화
  - 기존의 불필요한 '현재'와의 비교 및 관련 에러타입 제거
  - event 관련 검증 로직을 생성/수정 시 공통 검증 로직 + 생성 시에만 적용되는 로직(현재 < 모집마감) 으로 분리
  - update() 구조 개선: 값 계산 → 검증 → event 적용 순서로 정리 (기존에는 event에 먼저 적용 후 검증 실패 시 롤백하는 순서였습니다)


### 🔎 영향 범위
  <!-- 해당하는 항목만 남기고 나머지는 삭제해주세요 -->                                                                                                                                                                                    
- DB 스키마 변경
- API 스펙 변경

### 📡 API 변경사항 

| Method    | URL | 변경 내용 |
|-----------|-----|----------|
| POST | /events | registrationEndsAt 필드 not null |


### 🔥 관련 이슈
- closes #202
