### PR TITLE
204 신청취소 가능 시점 수정

### DIFF
--- a/src/main/kotlin/com/wafflestudio/spring2025/domain/event/repository/EventLockRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/spring2025/domain/event/repository/EventLockRepository.kt
@@ -8,11 +8,12 @@ class EventLockRepository(
     private val jdbcTemplate: JdbcTemplate,
 ) {
     fun lockIdByPublicId(publicId: String): Long? =
-        jdbcTemplate.query(
-            "SELECT id FROM events WHERE public_id = ? FOR UPDATE",
-            { rs, _ -> rs.getLong("id") },
-            publicId,
-        ).firstOrNull()
+        jdbcTemplate
+            .query(
+                "SELECT id FROM events WHERE public_id = ? FOR UPDATE",
+                { rs, _ -> rs.getLong("id") },
+                publicId,
+            ).firstOrNull()
 
     fun lockById(eventId: Long): Boolean {
         val result =

--- a/src/main/kotlin/com/wafflestudio/spring2025/domain/registration/service/RegistrationService.kt
+++ b/src/main/kotlin/com/wafflestudio/spring2025/domain/registration/service/RegistrationService.kt
@@ -254,6 +254,10 @@ RegistrationService(
 
         eventLockRepository.lockById(registration.eventId)
 
+        if (!isRegistrationEnabled(event)) {
+            throw RegistrationValidationException(RegistrationErrorCode.NOT_WITHIN_REGISTRATION_WINDOW)
+        }
+
         val wasConfirmed = registration.status == RegistrationStatus.CONFIRMED
         registrationRepository.deleteById(requireNotNull(registration.id))
 
@@ -375,10 +379,6 @@ RegistrationService(
         val registration =
             registrationRepository.lockByRegistrationPublicId(registrationId)
                 ?: throw RegistrationNotFoundException()
-
-        if (!isRegistrationEnabled(event)) {
-            throw RegistrationValidationException(RegistrationErrorCode.NOT_WITHIN_REGISTRATION_WINDOW)
-        }
 
         val isHost = userId != null && userId == event.createdBy
 //        val isRegistrant = userId != null && registration.userId == userId

--- a/src/main/kotlin/com/wafflestudio/spring2025/domain/registration/service/RegistrationService.kt
+++ b/src/main/kotlin/com/wafflestudio/spring2025/domain/registration/service/RegistrationService.kt
@@ -252,6 +252,8 @@ RegistrationService(
             }
         }
 
+        eventLockRepository.lockById(registration.eventId)
+
         val wasConfirmed = registration.status == RegistrationStatus.CONFIRMED
         registrationRepository.deleteById(requireNotNull(registration.id))
 

--- a/src/main/kotlin/com/wafflestudio/spring2025/domain/registration/service/RegistrationService.kt
+++ b/src/main/kotlin/com/wafflestudio/spring2025/domain/registration/service/RegistrationService.kt
@@ -252,6 +252,10 @@ RegistrationService(
             }
         }
 
+        if (!isRegistrationEnabled(event)) {
+            throw RegistrationValidationException(RegistrationErrorCode.NOT_WITHIN_REGISTRATION_WINDOW)
+        }
+
         val wasConfirmed = registration.status == RegistrationStatus.CONFIRMED
         registrationRepository.deleteById(requireNotNull(registration.id))
 
@@ -373,10 +377,6 @@ RegistrationService(
         val registration =
             registrationRepository.lockByRegistrationPublicId(registrationId)
                 ?: throw RegistrationNotFoundException()
-
-        if (!isRegistrationEnabled(event)) {
-            throw RegistrationValidationException(RegistrationErrorCode.NOT_WITHIN_REGISTRATION_WINDOW)
-        }
 
         val isHost = userId != null && userId == event.createdBy
 //        val isRegistrant = userId != null && registration.userId == userId

--- a/src/main/kotlin/com/wafflestudio/spring2025/domain/registration/service/RegistrationService.kt
+++ b/src/main/kotlin/com/wafflestudio/spring2025/domain/registration/service/RegistrationService.kt
@@ -232,12 +232,20 @@ RegistrationService(
         guestEmail: String?,
         registrationPublicId: String,
     ) {
-        val registration =
+        // eventId를 얻기 위한 미리보기 조회 (락 없음)
+        val preview =
             registrationRepository.findByRegistrationPublicId(registrationPublicId)
                 ?: throw RegistrationNotFoundException()
 
+        // 이벤트 업데이트와 경합 시 취소 가능 시점 판정을 일관되게 하기 위해 선락
+        eventLockRepository.lockById(preview.eventId)
         val event =
-            eventRepository.findById(registration.eventId).orElseThrow { EventNotFoundException() }
+            eventRepository.findById(preview.eventId).orElseThrow { EventNotFoundException() }
+
+        // 이벤트 락 획득 후 registration 행 락
+        val registration =
+            registrationRepository.lockByRegistrationPublicId(registrationPublicId)
+                ?: throw RegistrationNotFoundException()
 
         if (userId != null) {
             if (registration.userId != userId) {

--- a/src/test/kotlin/com/wafflestudio/spring2025/RegistrationIntegrationTest.kt
+++ b/src/test/kotlin/com/wafflestudio/spring2025/RegistrationIntegrationTest.kt
@@ -319,6 +319,187 @@ class RegistrationIntegrationTest
         }
 
         @Test
+        fun `모집 시작 전에는 자발적 취소를 할 수 없다`() {
+            val (host, _) = dataGenerator.generateUser()
+            val (participant, participantToken) = dataGenerator.generateUser()
+            val now = Instant.now()
+            val event =
+                createEvent(
+                    createdBy = host.id!!,
+                    title = "Before Registration Opens - Cancel",
+                    registrationStartsAt = now.plusSeconds(3600),
+                    registrationEndsAt = now.plusSeconds(7200),
+                )
+            val registration =
+                registrationRepository.save(
+                    Registration(
+                        userId = participant.id!!,
+                        eventId = event.id!!,
+                        status = RegistrationStatus.CONFIRMED,
+                    ),
+                )
+
+            mvc
+                .perform(
+                    delete("/api/registrations/${registration.registrationPublicId}")
+                        .header("Authorization", "Bearer $participantToken")
+                        .content(mapper.writeValueAsString(DeleteRegistrationRequest()))
+                        .contentType(MediaType.APPLICATION_JSON),
+                ).andExpect(status().isBadRequest)
+                .andExpect(jsonPath("$.code").value("NOT_WITHIN_REGISTRATION_WINDOW"))
+        }
+
+        @Test
+        fun `모집 마감 후에는 자발적 취소를 할 수 없다`() {
+            val (host, _) = dataGenerator.generateUser()
+            val (participant, participantToken) = dataGenerator.generateUser()
+            val now = Instant.now()
+            val event =
+                createEvent(
+                    createdBy = host.id!!,
+                    title = "After Registration Closed - Cancel",
+                    registrationStartsAt = now.minusSeconds(7200),
+                    registrationEndsAt = now.minusSeconds(60),
+                )
+            val registration =
+                registrationRepository.save(
+                    Registration(
+                        userId = participant.id!!,
+                        eventId = event.id!!,
+                        status = RegistrationStatus.CONFIRMED,
+                    ),
+                )
+
+            mvc
+                .perform(
+                    delete("/api/registrations/${registration.registrationPublicId}")
+                        .header("Authorization", "Bearer $participantToken")
+                        .content(mapper.writeValueAsString(DeleteRegistrationRequest()))
+                        .contentType(MediaType.APPLICATION_JSON),
+                ).andExpect(status().isBadRequest)
+                .andExpect(jsonPath("$.code").value("NOT_WITHIN_REGISTRATION_WINDOW"))
+        }
+
+        @Test
+        fun `모집 시작 전에도 주최자는 BANNED 처리를 할 수 있다`() {
+            val (host, hostToken) = dataGenerator.generateUser()
+            val (participant, _) = dataGenerator.generateUser()
+            val now = Instant.now()
+            val event =
+                createEvent(
+                    createdBy = host.id!!,
+                    title = "Ban Before Registration Opens",
+                    registrationStartsAt = now.plusSeconds(3600),
+                    registrationEndsAt = now.plusSeconds(7200),
+                )
+            val registration =
+                registrationRepository.save(
+                    Registration(
+                        userId = participant.id!!,
+                        eventId = event.id!!,
+                        status = RegistrationStatus.CONFIRMED,
+                    ),
+                )
+
+            mvc
+                .perform(
+                    patch("/api/registrations/${registration.registrationPublicId}")
+                        .header("Authorization", "Bearer $hostToken")
+                        .content(
+                            mapper.writeValueAsString(
+                                UpdateRegistrationStatusRequest(status = RegistrationStatus.BANNED),
+                            ),
+                        ).contentType(MediaType.APPLICATION_JSON),
+                ).andExpect(status().isOk)
+
+            assertEquals(RegistrationStatus.BANNED, findRegistration(registration.registrationPublicId).status)
+        }
+
+        @Test
+        fun `모집 마감 후에도 주최자는 BANNED 처리를 할 수 있다`() {
+            val (host, hostToken) = dataGenerator.generateUser()
+            val (participant, _) = dataGenerator.generateUser()
+            val now = Instant.now()
+            val event =
+                createEvent(
+                    createdBy = host.id!!,
+                    title = "Ban After Registration Closed",
+                    registrationStartsAt = now.minusSeconds(7200),
+                    registrationEndsAt = now.minusSeconds(60),
+                )
+            val registration =
+                registrationRepository.save(
+                    Registration(
+                        userId = participant.id!!,
+                        eventId = event.id!!,
+                        status = RegistrationStatus.CONFIRMED,
+                    ),
+                )
+
+            mvc
+                .perform(
+                    patch("/api/registrations/${registration.registrationPublicId}")
+                        .header("Authorization", "Bearer $hostToken")
+                        .content(
+                            mapper.writeValueAsString(
+                                UpdateRegistrationStatusRequest(status = RegistrationStatus.BANNED),
+                            ),
+                        ).contentType(MediaType.APPLICATION_JSON),
+                ).andExpect(status().isOk)
+
+            assertEquals(RegistrationStatus.BANNED, findRegistration(registration.registrationPublicId).status)
+        }
+
+        @Test
+        fun `모집 마감 후 BANNED 처리 시 대기자는 승격되지 않는다`() {
+            val (host, hostToken) = dataGenerator.generateUser()
+            val (confirmedUser, _) = dataGenerator.generateUser()
+            val (waitlistedUser, _) = dataGenerator.generateUser()
+            val now = Instant.now()
+            val event =
+                createEvent(
+                    createdBy = host.id!!,
+                    title = "Ban After Closed - No Promotion",
+                    capacity = 1,
+                    waitlistEnabled = true,
+                    registrationStartsAt = now.minusSeconds(7200),
+                    registrationEndsAt = now.minusSeconds(60),
+                )
+            val confirmedReg =
+                registrationRepository.save(
+                    Registration(
+                        userId = confirmedUser.id!!,
+                        eventId = event.id!!,
+                        status = RegistrationStatus.CONFIRMED,
+                    ),
+                )
+            val waitlistedReg =
+                registrationRepository.save(
+                    Registration(
+                        userId = waitlistedUser.id!!,
+                        eventId = event.id!!,
+                        status = RegistrationStatus.WAITLISTED,
+                    ),
+                )
+
+            mvc
+                .perform(
+                    patch("/api/registrations/${confirmedReg.registrationPublicId}")
+                        .header("Authorization", "Bearer $hostToken")
+                        .content(
+                            mapper.writeValueAsString(
+                                UpdateRegistrationStatusRequest(status = RegistrationStatus.BANNED),
+                            ),
+                        ).contentType(MediaType.APPLICATION_JSON),
+                ).andExpect(status().isOk)
+
+            assertEquals(RegistrationStatus.BANNED, findRegistration(confirmedReg.registrationPublicId).status)
+            assertEquals(RegistrationStatus.WAITLISTED, findRegistration(waitlistedReg.registrationPublicId).status)
+        }
+
+        // ─────────────────────────────────────────────────────────────────────────
+
+        @Test
         fun `주최자만 참여자 이메일을 볼 수 있고 참여자는 볼 수 없다`() {
             val (host, hostToken) = dataGenerator.generateUser()
             val (participant, participantToken) = dataGenerator.generateUser()


### PR DESCRIPTION
## ✨ Feature PR (to dev)

> **중요: 202 -> 203 -> 204 순으로 리뷰 후 머지해주세요!!!**

### 🧪 로컬 테스트 여부 (작업자 체크)
- [x] 로컬에서 Swagger 혹은 테스트 코드로 동작을 확인했습니다.

### 📄 documentation 최신화 여부
> 변경사항과 관련된 API의 swagger documentation이 실제 동작과 일치하는지 확인합니다.
- [ ] (작업자) 확인하였습니다.
- [ ] (리뷰어) 확인하였습니다.

### 📌 작업 내용(what & why)

- 새로 정한 규칙에 따라 강제취소는 항상, 자발적 취소는 모집기간 내에만 가능하도록 수정하였습니다. (기존에는 반대로 되어 있었음)
- 관련 테스트케이스 추가 및 통과 확인하였습니다.

### 🔥 관련 이슈
- closes #204
