### PR TITLE
Feat/203 일정 삭제 정책 수정

### DIFF
--- a/src/main/kotlin/com/wafflestudio/spring2025/common/email/service/EmailService.kt
+++ b/src/main/kotlin/com/wafflestudio/spring2025/common/email/service/EmailService.kt
@@ -118,6 +118,17 @@ class EmailService(
         val description: String?,
     )
 
+    data class EventCancellationEmailData(
+        val toEmail: String,
+        val name: String,
+        val eventTitle: String?,
+        val startsAt: Instant?,
+        val endsAt: Instant?,
+        val location: String?,
+        val description: String?,
+        val hostEmail: String,
+    )
+
     fun sendRegistrationStatusEmail(data: RegistrationStatusEmailData) {
         when (data.status) {
             RegistrationStatus.CONFIRMED -> {
@@ -219,6 +230,25 @@ class EmailService(
         )
 
         logger.info("신청 삭제 정보가 ${data.toEmail} 로 전달되었습니다.")
+    }
+
+    fun sendEventCancellationEmail(data: EventCancellationEmailData) {
+        val htmlContent =
+            loadTemplate("event-cancelled.html")
+                .replace("{name}", data.name)
+                .replace("{eventTitle}", formatEventTitle(data.eventTitle))
+                .replace("{eventDateRange}", formatEventDateRange(data.startsAt, data.endsAt, "-"))
+                .replace("{location}", formatLocation(data.location))
+                .replace("{hostEmail}", data.hostEmail)
+                .replace("{description}", formatDescription(data.description))
+
+        sendHtmlEmail(
+            to = data.toEmail,
+            subject = emailName("일정 취소", data.eventTitle),
+            htmlContent = htmlContent,
+        )
+
+        logger.info("일정 취소 정보가 ${data.toEmail} 로 전달되었습니다.")
     }
 
     fun sendWaitlistPromotionEmail(

--- a/src/main/kotlin/com/wafflestudio/spring2025/domain/event/exception/EventErrorCode.kt
+++ b/src/main/kotlin/com/wafflestudio/spring2025/domain/event/exception/EventErrorCode.kt
@@ -93,9 +93,4 @@ enum class EventErrorCode(
         title = "정원이 초과되었습니다.",
         message = "모임 정원이 가득 차\n더 이상 신청할 수 없습니다.",
     ),
-    EVENT_HAS_CONFIRMED_REGISTRATIONS(
-        httpStatusCode = HttpStatus.CONFLICT,
-        title = "확정된 참가자가 있습니다.",
-        message = "확정된 참가자가 있는 모임은 삭제할 수 없습니다.",
-    ),
 }

--- a/src/main/kotlin/com/wafflestudio/spring2025/domain/event/exception/EventErrorCode.kt
+++ b/src/main/kotlin/com/wafflestudio/spring2025/domain/event/exception/EventErrorCode.kt
@@ -88,9 +88,4 @@ enum class EventErrorCode(
         title = "정원이 초과되었습니다.",
         message = "모임 정원이 가득 차\n더 이상 신청할 수 없습니다.",
     ),
-    EVENT_HAS_CONFIRMED_REGISTRATIONS(
-        httpStatusCode = HttpStatus.CONFLICT,
-        title = "확정된 참가자가 있습니다.",
-        message = "확정된 참가자가 있는 모임은 삭제할 수 없습니다.",
-    ),
 }

--- a/src/main/kotlin/com/wafflestudio/spring2025/domain/event/exception/EventException.kt
+++ b/src/main/kotlin/com/wafflestudio/spring2025/domain/event/exception/EventException.kt
@@ -19,8 +19,6 @@ class EventForbiddenException : EventException(error = EventErrorCode.NOT_EVENT_
 
 class EventFullException : EventException(error = EventErrorCode.EVENT_FULL)
 
-class EventHasConfirmedRegistrationsException : EventException(error = EventErrorCode.EVENT_HAS_CONFIRMED_REGISTRATIONS)
-
 class EventValidationException(
     error: EventErrorCode,
 ) : EventException(error = error)

--- a/src/main/kotlin/com/wafflestudio/spring2025/domain/event/repository/EventLockRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/spring2025/domain/event/repository/EventLockRepository.kt
@@ -8,11 +8,12 @@ class EventLockRepository(
     private val jdbcTemplate: JdbcTemplate,
 ) {
     fun lockById(eventId: Long): Boolean {
-        val result = jdbcTemplate.query(
-            "SELECT id FROM events WHERE id = ? FOR UPDATE",
-            { rs, _ -> rs.getLong("id") },
-            eventId,
-        )
+        val result =
+            jdbcTemplate.query(
+                "SELECT id FROM events WHERE id = ? FOR UPDATE",
+                { rs, _ -> rs.getLong("id") },
+                eventId,
+            )
         return result.isNotEmpty()
     }
 }

--- a/src/main/kotlin/com/wafflestudio/spring2025/domain/event/repository/EventLockRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/spring2025/domain/event/repository/EventLockRepository.kt
@@ -7,11 +7,12 @@ import org.springframework.stereotype.Repository
 class EventLockRepository(
     private val jdbcTemplate: JdbcTemplate,
 ) {
-    fun lockById(eventId: Long) {
-        jdbcTemplate.queryForObject(
+    fun lockById(eventId: Long): Boolean {
+        val result = jdbcTemplate.query(
             "SELECT id FROM events WHERE id = ? FOR UPDATE",
-            Long::class.java,
+            { rs, _ -> rs.getLong("id") },
             eventId,
         )
+        return result.isNotEmpty()
     }
 }

--- a/src/main/kotlin/com/wafflestudio/spring2025/domain/event/repository/EventLockRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/spring2025/domain/event/repository/EventLockRepository.kt
@@ -8,11 +8,12 @@ class EventLockRepository(
     private val jdbcTemplate: JdbcTemplate,
 ) {
     fun lockIdByPublicId(publicId: String): Long? =
-        jdbcTemplate.query(
-            "SELECT id FROM events WHERE public_id = ? FOR UPDATE",
-            { rs, _ -> rs.getLong("id") },
-            publicId,
-        ).firstOrNull()
+        jdbcTemplate
+            .query(
+                "SELECT id FROM events WHERE public_id = ? FOR UPDATE",
+                { rs, _ -> rs.getLong("id") },
+                publicId,
+            ).firstOrNull()
 
     fun lockById(eventId: Long): Boolean {
         val result =

--- a/src/main/kotlin/com/wafflestudio/spring2025/domain/event/repository/EventLockRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/spring2025/domain/event/repository/EventLockRepository.kt
@@ -7,6 +7,13 @@ import org.springframework.stereotype.Repository
 class EventLockRepository(
     private val jdbcTemplate: JdbcTemplate,
 ) {
+    fun lockIdByPublicId(publicId: String): Long? =
+        jdbcTemplate.query(
+            "SELECT id FROM events WHERE public_id = ? FOR UPDATE",
+            { rs, _ -> rs.getLong("id") },
+            publicId,
+        ).firstOrNull()
+
     fun lockById(eventId: Long): Boolean {
         val result =
             jdbcTemplate.query(

--- a/src/main/kotlin/com/wafflestudio/spring2025/domain/event/service/EventService.kt
+++ b/src/main/kotlin/com/wafflestudio/spring2025/domain/event/service/EventService.kt
@@ -1,5 +1,6 @@
 package com.wafflestudio.spring2025.domain.event.service
 
+import com.wafflestudio.spring2025.common.email.service.EmailService
 import com.wafflestudio.spring2025.common.image.service.ImageService
 import com.wafflestudio.spring2025.domain.event.dto.response.CapabilitiesInfo
 import com.wafflestudio.spring2025.domain.event.dto.response.CreatorInfo
@@ -12,7 +13,6 @@ import com.wafflestudio.spring2025.domain.event.dto.response.ViewerInfo
 import com.wafflestudio.spring2025.domain.event.dto.response.ViewerStatus
 import com.wafflestudio.spring2025.domain.event.exception.EventErrorCode
 import com.wafflestudio.spring2025.domain.event.exception.EventForbiddenException
-import com.wafflestudio.spring2025.domain.event.exception.EventHasConfirmedRegistrationsException
 import com.wafflestudio.spring2025.domain.event.exception.EventNotFoundException
 import com.wafflestudio.spring2025.domain.event.exception.EventValidationException
 import com.wafflestudio.spring2025.domain.event.model.Event
@@ -26,6 +26,8 @@ import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Sort
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import org.springframework.transaction.support.TransactionSynchronization
+import org.springframework.transaction.support.TransactionSynchronizationManager
 import java.time.Instant
 import java.util.UUID
 
@@ -37,6 +39,7 @@ class EventService(
     private val waitlistReconciliationService: WaitlistReconciliationService,
     private val userRepository: UserRepository,
     private val imageService: ImageService,
+    private val emailService: EmailService,
 ) {
     /**
      * 일정 생성
@@ -364,23 +367,50 @@ class EventService(
         return savedEvent
     }
 
+    @Transactional
     fun delete(
         publicId: String,
         requesterId: Long,
     ) {
         val event = getEventByPublicId(publicId)
         requireCreator(event, requesterId)
-        val confirmedNumber =
-            registrationRepository
-                .countByEventIdAndStatus(
-                    eventID = requireNotNull(event.id),
-                    registrationStatus = RegistrationStatus.CONFIRMED,
-                ).toInt()
+        val eventId = requireNotNull(event.id)
 
-        if (confirmedNumber > 0) {
-            throw EventHasConfirmedRegistrationsException()
-        } else {
-            eventRepository.deleteById(requireNotNull(event.id))
+        // 알림 대상: CONFIRMED + WAITLISTED (BANNED 제외)
+        val registrationsToNotify =
+            registrationRepository.findByEventId(eventId)
+                .filter { it.status == RegistrationStatus.CONFIRMED || it.status == RegistrationStatus.WAITLISTED }
+
+        // 이메일 데이터 구성 (삭제 전에 user 정보 조회)
+        val hostUser = userRepository.findById(event.createdBy).orElseThrow { EventNotFoundException() }
+        val userIds = registrationsToNotify.mapNotNull { it.userId }.distinct()
+        val usersById = userRepository.findAllById(userIds).associateBy { it.id!! }
+
+        val emailDataList =
+            registrationsToNotify.mapNotNull { reg ->
+                val user = reg.userId?.let { usersById[it] }
+                val toEmail = user?.email ?: reg.guestEmail
+                if (toEmail.isNullOrBlank()) return@mapNotNull null
+                EmailService.EventCancellationEmailData(
+                    toEmail = toEmail,
+                    name = user?.name ?: reg.guestName ?: "참여자",
+                    eventTitle = event.title,
+                    startsAt = event.startsAt,
+                    endsAt = event.endsAt,
+                    location = event.location,
+                    description = event.description,
+                    hostEmail = hostUser.email,
+                )
+            }
+
+        // FK 제약으로 인해 event 삭제 전 registrations 먼저 삭제
+        registrationRepository.deleteByEventId(eventId)
+        eventRepository.deleteById(eventId)
+
+        afterCommit {
+            emailDataList.forEach { data ->
+                emailService.sendEventCancellationEmail(data)
+            }
         }
     }
 
@@ -470,6 +500,20 @@ class EventService(
         previousCapacity: Int?,
         newCapacity: Int?,
     ): Boolean = previousCapacity != null && newCapacity != null && newCapacity > previousCapacity
+
+    private fun afterCommit(action: () -> Unit) {
+        if (!TransactionSynchronizationManager.isActualTransactionActive()) {
+            action()
+            return
+        }
+        TransactionSynchronizationManager.registerSynchronization(
+            object : TransactionSynchronization {
+                override fun afterCommit() {
+                    action()
+                }
+            },
+        )
+    }
 
     private fun buildCapabilities(
         viewerStatus: ViewerStatus,

--- a/src/main/kotlin/com/wafflestudio/spring2025/domain/event/service/EventService.kt
+++ b/src/main/kotlin/com/wafflestudio/spring2025/domain/event/service/EventService.kt
@@ -379,7 +379,8 @@ class EventService(
 
         // 알림 대상: CONFIRMED + WAITLISTED (BANNED 제외)
         val registrationsToNotify =
-            registrationRepository.findByEventId(eventId)
+            registrationRepository
+                .findByEventId(eventId)
                 .filter { it.status == RegistrationStatus.CONFIRMED || it.status == RegistrationStatus.WAITLISTED }
 
         // 이메일 데이터 구성 (삭제 전에 user 정보 조회)

--- a/src/main/kotlin/com/wafflestudio/spring2025/domain/event/service/EventService.kt
+++ b/src/main/kotlin/com/wafflestudio/spring2025/domain/event/service/EventService.kt
@@ -375,6 +375,7 @@ class EventService(
         val event = getEventByPublicId(publicId)
         requireCreator(event, requesterId)
         val eventId = requireNotNull(event.id)
+        eventLockRepository.lockById(eventId)
 
         // 알림 대상: CONFIRMED + WAITLISTED (BANNED 제외)
         val registrationsToNotify =
@@ -382,7 +383,7 @@ class EventService(
                 .filter { it.status == RegistrationStatus.CONFIRMED || it.status == RegistrationStatus.WAITLISTED }
 
         // 이메일 데이터 구성 (삭제 전에 user 정보 조회)
-        val hostUser = userRepository.findById(event.createdBy).orElseThrow { EventNotFoundException() }
+        val hostUser = userRepository.findById(event.createdBy).orElse(null)
         val userIds = registrationsToNotify.mapNotNull { it.userId }.distinct()
         val usersById = userRepository.findAllById(userIds).associateBy { it.id!! }
 
@@ -399,7 +400,7 @@ class EventService(
                     endsAt = event.endsAt,
                     location = event.location,
                     description = event.description,
-                    hostEmail = hostUser.email,
+                    hostEmail = hostUser?.email ?: "",
                 )
             }
 

--- a/src/main/kotlin/com/wafflestudio/spring2025/domain/event/service/EventService.kt
+++ b/src/main/kotlin/com/wafflestudio/spring2025/domain/event/service/EventService.kt
@@ -325,7 +325,7 @@ class EventService(
         val event = getEventByPublicId(publicId)
         requireCreator(event, requesterId)
         val eventId = requireNotNull(event.id) { "Event id is null: publicId=$publicId" }
-        eventLockRepository.lockById(eventId)
+        if (!eventLockRepository.lockById(eventId)) throw EventNotFoundException()
         val previousCapacity = event.capacity
 
         val confirmedParticipants = countConfirmedParticipants(eventId)
@@ -375,7 +375,7 @@ class EventService(
         val event = getEventByPublicId(publicId)
         requireCreator(event, requesterId)
         val eventId = requireNotNull(event.id)
-        eventLockRepository.lockById(eventId)
+        if (!eventLockRepository.lockById(eventId)) throw EventNotFoundException()
 
         // 알림 대상: CONFIRMED + WAITLISTED (BANNED 제외)
         val registrationsToNotify =

--- a/src/main/kotlin/com/wafflestudio/spring2025/domain/event/service/EventService.kt
+++ b/src/main/kotlin/com/wafflestudio/spring2025/domain/event/service/EventService.kt
@@ -372,10 +372,9 @@ class EventService(
         publicId: String,
         requesterId: Long,
     ) {
-        val event = getEventByPublicId(publicId)
+        val eventId = eventLockRepository.lockIdByPublicId(publicId) ?: throw EventNotFoundException()
+        val event = eventRepository.findById(eventId).orElseThrow { EventNotFoundException() }
         requireCreator(event, requesterId)
-        val eventId = requireNotNull(event.id)
-        if (!eventLockRepository.lockById(eventId)) throw EventNotFoundException()
 
         // 알림 대상: CONFIRMED + WAITLISTED (BANNED 제외)
         val registrationsToNotify =

--- a/src/main/kotlin/com/wafflestudio/spring2025/domain/registration/repository/RegistrationRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/spring2025/domain/registration/repository/RegistrationRepository.kt
@@ -12,6 +12,8 @@ interface RegistrationRepository :
     PagingAndSortingRepository<Registration, Long> {
     fun findByEventId(eventId: Long): List<Registration>
 
+    fun deleteByEventId(eventId: Long)
+
     fun findByRegistrationPublicId(registrationPublicId: String): Registration?
 
     @Query(

--- a/src/main/kotlin/com/wafflestudio/spring2025/domain/registration/service/RegistrationService.kt
+++ b/src/main/kotlin/com/wafflestudio/spring2025/domain/registration/service/RegistrationService.kt
@@ -252,6 +252,8 @@ RegistrationService(
             }
         }
 
+        eventLockRepository.lockById(registration.eventId)
+
         val wasConfirmed = registration.status == RegistrationStatus.CONFIRMED
         registrationRepository.deleteById(requireNotNull(registration.id))
 

--- a/src/main/kotlin/com/wafflestudio/spring2025/domain/registration/service/RegistrationService.kt
+++ b/src/main/kotlin/com/wafflestudio/spring2025/domain/registration/service/RegistrationService.kt
@@ -71,7 +71,7 @@ RegistrationService(
         val capacity = lockedEvent.capacity ?: throw IllegalStateException("이벤트의 capacity가 설정되어 있지 않습니다.")
         val currentConfirmed =
             registrationRepository
-                .countByEventIdAndStatusWithLock(eventPk, RegistrationStatus.CONFIRMED)
+                .countByEventIdAndStatus(eventPk, RegistrationStatus.CONFIRMED)
                 .toInt()
 
         val status =
@@ -232,20 +232,12 @@ RegistrationService(
         guestEmail: String?,
         registrationPublicId: String,
     ) {
-        // eventId를 얻기 위한 미리보기 조회 (락 없음)
-        val preview =
+        val registration =
             registrationRepository.findByRegistrationPublicId(registrationPublicId)
                 ?: throw RegistrationNotFoundException()
 
-        // create()와 동일한 락 순서(event → registration)로 통일해 데드락 방지
-        eventLockRepository.lockById(preview.eventId)
         val event =
-            eventRepository.findById(preview.eventId).orElseThrow { EventNotFoundException() }
-
-        // event 락 획득 후 registration 행 락
-        val registration =
-            registrationRepository.lockByRegistrationPublicId(registrationPublicId)
-                ?: throw RegistrationNotFoundException()
+            eventRepository.findById(registration.eventId).orElseThrow { EventNotFoundException() }
 
         if (userId != null) {
             if (registration.userId != userId) {
@@ -680,7 +672,7 @@ RegistrationService(
 
         val capacity = event.capacity ?: throw IllegalStateException("이벤트의 capacity가 설정되어 있지 않습니다.")
         val confirmed =
-            registrationRepository.countByEventIdAndStatusWithLock(eventId, RegistrationStatus.CONFIRMED).toInt()
+            registrationRepository.countByEventIdAndStatus(eventId, RegistrationStatus.CONFIRMED).toInt()
         val available = capacity - confirmed
         if (available <= 0) return
 

--- a/src/main/resources/com/wafflestudio/spring2025/common/email/template/event-cancelled.html
+++ b/src/main/resources/com/wafflestudio/spring2025/common/email/template/event-cancelled.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="ko">
+
+<head>
+    <meta charset="UTF-8">
+</head>
+
+<body
+    style="margin: 0; padding: 0; background-color: #ffffff; font-family: 'Apple SD Gothic Neo', 'Malgun Gothic', sans-serif;">
+    <table align="center" border="0" cellpadding="0" cellspacing="0" width="100%"
+        style="max-width: 450px; margin: 0 auto; background-color: #ffffff;">
+        <tr>
+            <td style="padding: 30px 20px;">
+
+                <table border="0" cellpadding="0" cellspacing="0" width="100%" style="margin-bottom: 30px;">
+                    <tr>
+                        <td>
+                            <img src="https://raw.githubusercontent.com/wafflestudio/moiming-web/refs/heads/main/public/moiming-logo.png"
+                                 alt="모이밍" width="120" style="display: block; border: 0;">
+                        </td>
+                    </tr>
+                </table>
+
+                <table border="0" cellpadding="0" cellspacing="0" width="100%" style="margin-bottom: 30px;">
+                    <tr>
+                        <td width="48" style="vertical-align: middle;">
+                            <div style="width: 48px; height: 48px; background-color: #EC221F; border-radius: 50%;">
+                                <table border="0" cellpadding="0" cellspacing="0" width="48" height="48">
+                                    <tr>
+                                        <td align="center" valign="middle" style="height: 48px; line-height: 0;">
+                                            <img src="https://raw.githubusercontent.com/wafflestudio/moiming-web/refs/heads/main/public/x.png"
+                                                 alt="x-mark" width="20" style="display: block; border: 0;">
+                                        </td>
+                                    </tr>
+                                </table>
+                            </div>
+                        </td>
+                        <td
+                            style="padding-left: 15px; font-size: 22px; font-weight: bold; line-height: 1.3; color: #111;">
+                            안녕하세요 {name}님<br>
+                            일정이 취소되었습니다.
+                        </td>
+                    </tr>
+                </table>
+
+                <div style="border: 1px solid #EAEAEA; border-radius: 12px; padding: 24px; margin-bottom: 30px;">
+                    <div style="font-size: 20px; font-weight: bold; color: #000; margin-bottom: 20px;">{eventTitle}
+                    </div>
+
+                    <table border="0" cellpadding="0" cellspacing="0" width="100%"
+                        style="font-size: 15px; color: #777; line-height: 1.6;">
+                        <tr>
+                            <td width="20" style="padding-bottom: 12px; vertical-align: middle;">
+                                <img src="https://raw.githubusercontent.com/wafflestudio/moiming-web/refs/heads/main/public/calendar.png"
+                                     alt="calendar" width="20" style="display: block; border: 0;">
+                            </td>
+                            <td style="padding-bottom: 12px; padding-left: 10px; vertical-align: middle;">
+                                일시 <span style="margin-left:8px; color:#444;">{eventDateRange}</span>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td style="padding-bottom: 4px; vertical-align: middle;">
+                                <img src="https://raw.githubusercontent.com/wafflestudio/moiming-web/refs/heads/main/public/map-pin.png"
+                                     alt="map-pin" width="20" style="display: block; border: 0;">
+                            </td>
+                            <td style="padding-bottom: 4px; padding-left: 10px; vertical-align: middle;">
+                                장소 <span style="margin-left:8px; color:#444;">{location}</span>
+                            </td>
+                        </tr>
+                    </table>
+                </div>
+
+                <table border="0" cellpadding="0" cellspacing="0" width="100%"
+                    style="background-color: #F7F8F9; border-radius: 8px; margin-bottom: 30px;">
+                    <tr>
+                        <td style="padding: 14px 16px; font-size: 14px; color: #444; vertical-align: middle;">
+                            <table border="0" cellpadding="0" cellspacing="0">
+                                <tr>
+                                    <td style="vertical-align: middle; padding-right: 8px;">
+                                        <img src="https://raw.githubusercontent.com/wafflestudio/moiming-web/refs/heads/main/public/user.png"
+                                             alt="user" width="20" style="display: block; border: 0;">
+                                    </td>
+                                    <td style="vertical-align: middle;">
+                                        <strong style="font-weight: bold;">문의:</strong>
+                                        <span style="margin-left: 4px;">일정 주최자에게 연락 바랍니다 ({hostEmail})</span>
+                                    </td>
+                                </tr>
+                            </table>
+                        </td>
+                    </tr>
+                </table>
+
+                <div
+                    style="font-size: 16px; line-height: 1.7; color: #333; margin-bottom: 50px; white-space: wrap; word-break: break-all;">
+                    {description}</div>
+
+            </td>
+        </tr>
+    </table>
+</body>
+
+</html>

--- a/src/main/resources/db/migration/V14__make_registration_ends_at_not_null.sql
+++ b/src/main/resources/db/migration/V14__make_registration_ends_at_not_null.sql
@@ -1,2 +1,3 @@
+DELETE r FROM registrations r INNER JOIN events e ON r.event_id = e.id WHERE e.registration_ends_at IS NULL;
 DELETE FROM events WHERE registration_ends_at IS NULL;
 ALTER TABLE events MODIFY registration_ends_at DATETIME(6) NOT NULL;

--- a/src/test/kotlin/com/wafflestudio/spring2025/EventIntegrationTest.kt
+++ b/src/test/kotlin/com/wafflestudio/spring2025/EventIntegrationTest.kt
@@ -1155,7 +1155,9 @@ class EventIntegrationTest
             val event = createEventInDb(createdBy = host.id!!, capacity = 2)
 
             registrationRepository.save(Registration(userId = confirmed.id!!, eventId = event.id!!, status = RegistrationStatus.CONFIRMED))
-            registrationRepository.save(Registration(userId = waitlisted.id!!, eventId = event.id!!, status = RegistrationStatus.WAITLISTED))
+            registrationRepository.save(
+                Registration(userId = waitlisted.id!!, eventId = event.id!!, status = RegistrationStatus.WAITLISTED),
+            )
             registrationRepository.save(Registration(userId = banned.id!!, eventId = event.id!!, status = RegistrationStatus.BANNED))
 
             mvc

--- a/src/test/kotlin/com/wafflestudio/spring2025/EventIntegrationTest.kt
+++ b/src/test/kotlin/com/wafflestudio/spring2025/EventIntegrationTest.kt
@@ -11,6 +11,10 @@ import com.wafflestudio.spring2025.domain.registration.model.RegistrationStatus
 import com.wafflestudio.spring2025.domain.registration.repository.RegistrationRepository
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.never
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
@@ -1122,7 +1126,7 @@ class EventIntegrationTest
         }
 
         @Test
-        fun `확정된 참가자가 있는 이벤트 삭제 요청 시 409를 반환한다`() {
+        fun `확정된 참가자가 있는 이벤트도 주최자가 삭제 시 204를 반환한다`() {
             val (user, token) = dataGenerator.generateUser()
             val (participant, _) = dataGenerator.generateUser()
             val event = createEventInDb(createdBy = user.id!!)
@@ -1139,7 +1143,60 @@ class EventIntegrationTest
                 .perform(
                     delete("/api/events/${event.publicId}")
                         .header("Authorization", "Bearer $token"),
-                ).andExpect(status().isConflict)
-                .andExpect(jsonPath("$.code").value("EVENT_HAS_CONFIRMED_REGISTRATIONS"))
+                ).andExpect(status().isNoContent)
+        }
+
+        @Test
+        fun `이벤트 삭제 시 CONFIRMED와 WAITLISTED 신청자에게 이메일이 발송되고 BANNED에게는 발송되지 않는다`() {
+            val (host, token) = dataGenerator.generateUser()
+            val (confirmed, _) = dataGenerator.generateUser()
+            val (waitlisted, _) = dataGenerator.generateUser()
+            val (banned, _) = dataGenerator.generateUser()
+            val event = createEventInDb(createdBy = host.id!!, capacity = 2)
+
+            registrationRepository.save(Registration(userId = confirmed.id!!, eventId = event.id!!, status = RegistrationStatus.CONFIRMED))
+            registrationRepository.save(Registration(userId = waitlisted.id!!, eventId = event.id!!, status = RegistrationStatus.WAITLISTED))
+            registrationRepository.save(Registration(userId = banned.id!!, eventId = event.id!!, status = RegistrationStatus.BANNED))
+
+            mvc
+                .perform(
+                    delete("/api/events/${event.publicId}")
+                        .header("Authorization", "Bearer $token"),
+                ).andExpect(status().isNoContent)
+
+            verify(emailService, times(2)).sendEventCancellationEmail(any())
+        }
+
+        @Test
+        fun `이벤트 삭제 시 관련 registration도 모두 삭제된다`() {
+            val (host, token) = dataGenerator.generateUser()
+            val (p1, _) = dataGenerator.generateUser()
+            val (p2, _) = dataGenerator.generateUser()
+            val event = createEventInDb(createdBy = host.id!!, capacity = 1)
+
+            registrationRepository.save(Registration(userId = p1.id!!, eventId = event.id!!, status = RegistrationStatus.CONFIRMED))
+            registrationRepository.save(Registration(userId = p2.id!!, eventId = event.id!!, status = RegistrationStatus.WAITLISTED))
+
+            mvc
+                .perform(
+                    delete("/api/events/${event.publicId}")
+                        .header("Authorization", "Bearer $token"),
+                ).andExpect(status().isNoContent)
+
+            assertThat(registrationRepository.findByEventId(event.id!!)).isEmpty()
+        }
+
+        @Test
+        fun `신청자가 없는 이벤트 삭제 시 이메일이 발송되지 않는다`() {
+            val (user, token) = dataGenerator.generateUser()
+            val event = createEventInDb(createdBy = user.id!!)
+
+            mvc
+                .perform(
+                    delete("/api/events/${event.publicId}")
+                        .header("Authorization", "Bearer $token"),
+                ).andExpect(status().isNoContent)
+
+            verify(emailService, never()).sendEventCancellationEmail(any())
         }
     }


### PR DESCRIPTION
## ✨ Feature PR (to dev)

> **중요: Feat/202 PR을 먼저 리뷰 후 머지해주세요!!!!!!! 그 브랜치 위에 쌓은 거라서 base를 dev가 아닌 202 브랜치로 해놓았습니다. 202 먼저 머지하면 이 PR의 베이스가 자동으로 dev로 변경됩니다** 

### 🧪 로컬 테스트 여부 (작업자 체크)
- [x] 로컬에서 Swagger 혹은 테스트 코드로 동작을 확인했습니다.

### 📄 documentation 최신화 여부
> 변경사항과 관련된 API의 swagger documentation이 실제 동작과 일치하는지 확인합니다.
- [ ] (작업자) 확인하였습니다.
- [ ] (리뷰어) 확인하였습니다.

### 📌 작업 내용(what & why)

- 삭제 로직 (EventService.delete())                                                                                                                                                                                                                             
  - CONFIRMED + WAITLISTED 신청자만 이메일 알림 대상 (BANNED 제외)
  - 삭제 전에 유저 정보 조회 → 이메일 데이터 구성                                                                                                                                                                                                                 
  - registrations 먼저 삭제 → event 삭제 (FK 제약)
  - afterCommit에서 이메일 발송 (트랜잭션 커밋 후 실행)                                                                                                                                                                                                           
  - Pessimistic Lock으로 동시성 처리                                                                                                                                                                                                                              
                                                                                                                                                                                                                                                                  
- 이메일 (EmailService + event-cancelled.html)                                                                                                                                                                                                                    
  - sendEventCancellationEmail() 메서드 추가                                                                                                                                                                                                                      
  - HTML 템플릿: 제목/일시/장소/주최자 연락처/상세설명 포함                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                  
- 에러코드 정리                                                                                                                                                                                                                                                   
  - CANNOT_DELETE_EVENT_WITH_REGISTRATIONS 에러코드 및 예외 제거  

### 🔎 영향 범위
  <!-- 해당하는 항목만 남기고 나머지는 삭제해주세요 -->                                                                                                                                                                                    
- 동시성 / 트랜잭션 처리 영향

### 🔥 관련 이슈
- closes #203
