### PR TITLE
:bug: 소셜 로그인 시 프로필 이미지 null로 저장

### DIFF
--- a/src/main/kotlin/com/wafflestudio/spring2025/domain/auth/service/SocialAuthService.kt
+++ b/src/main/kotlin/com/wafflestudio/spring2025/domain/auth/service/SocialAuthService.kt
@@ -32,7 +32,7 @@ class SocialAuthService(
                 User(
                     email = userInfo.email,
                     name = userInfo.name,
-                    profileImage = userInfo.profilePicture,
+                    profileImage = null,
                     passwordHash = null,
                 ),
             )


### PR DESCRIPTION
## ✨ Feature PR (to dev)

### 🧪 로컬 테스트 여부 (작업자 체크)
- [ ] 로컬에서 Swagger 혹은 테스트 코드로 동작을 확인했습니다.

* 현재 작업 환경상 아직 테스트를 해보지 못했습니다만 한 줄 변경이라 괜찮을 것으로 예상합니다..!

### 📄 documentation 최신화 여부
> 변경사항과 관련된 API의 swagger documentation이 실제 동작과 일치하는지 확인합니다.
- [ ] (작업자) 확인하였습니다.
- [ ] (리뷰어) 확인하였습니다.

### 📌 작업 내용(what & why)

- 구글 회원가입 시 user의 profile_image 필드에 profileImage url을 저장하던 것을 없애고 null로 채우도록 했습니다.
- 현재 이미지 서비스 구현 방식 상 profile_image에는 url이 아닌 s3 key가 들어가야 하고, 더욱이 프로필 사진 자체를 활용하지 않고 있기 때문에 아예 저장하지 않도록 하였습니다.
- 이렇게 하면 구글 계정으로 로그인 시 GET /users/me에서 500 에러가 뜨지 않아 정상적으로 로그인 상태가 반영될 것으로 예상합니다.

### 🔥 관련 이슈
- closes #215
