### PR TITLE
:recycle: EmailClient 의존성 격리

### DIFF
--- a/src/main/kotlin/com/wafflestudio/spring2025/common/email/client/JavaMailEmailClient.kt
+++ b/src/main/kotlin/com/wafflestudio/spring2025/common/email/client/JavaMailEmailClient.kt
@@ -1,8 +1,12 @@
 package com.wafflestudio.spring2025.common.email.client
 
+import com.wafflestudio.spring2025.common.email.exception.EmailErrorCode
+import com.wafflestudio.spring2025.common.email.exception.EmailServiceUnavailableException
+import jakarta.mail.MessagingException
 import jakarta.mail.internet.MimeMessage
 import org.slf4j.LoggerFactory
 import org.springframework.context.annotation.Primary
+import org.springframework.mail.MailException
 import org.springframework.mail.javamail.JavaMailSender
 import org.springframework.mail.javamail.MimeMessageHelper
 import org.springframework.stereotype.Component
@@ -21,26 +25,25 @@ class JavaMailEmailClient(
         fromEmail: String,
         fromName: String,
     ) {
-        logger.info("메일링 임시 중단으로 발송 생략: $to")
-        return
+        // 지금 AWS SDK를 쓰는 게 아니라 그냥 email config를 AWS SES의 SMTP 엔드포인트로 해놓은 상황
+        // (SDK가 아닌 SMTP 방식으로 SES 사용)
         try {
             val message: MimeMessage = javaMailSender.createMimeMessage()
-
-            val helper = MimeMessageHelper(message, true, "UTF-8")
+            val helper = MimeMessageHelper(message, "UTF-8")
 
             helper.setTo(to)
             helper.setSubject(subject)
-
             helper.setText(htmlContent, true)
-
             helper.setFrom("$fromName <$fromEmail>")
 
+            // AWS SES 샌드박스 모드에서는 발신/수신 주소 모두 사전 인증(Verified)이 필요합니다.
             javaMailSender.send(message)
-
-            logger.info("Gmail을 통해 메일 발송 성공: $to")
-        } catch (e: Exception) {
-            logger.error("Gmail 메일 발송 실패: $to", e)
-            throw RuntimeException("Email sending failed via Gmail", e)
+        } catch (e: MessagingException) {
+            logger.error("메일 구성 실패: to={}, subject={}", to, subject, e)
+            throw EmailServiceUnavailableException(EmailErrorCode.EMAIL_SERVICE_UNAVAILABLE)
+        } catch (e: MailException) {
+            logger.error("메일 전송 실패: to={}, subject={}", to, subject, e)
+            throw EmailServiceUnavailableException(EmailErrorCode.EMAIL_SERVICE_UNAVAILABLE)
         }
     }
 }

--- a/src/main/kotlin/com/wafflestudio/spring2025/common/email/client/NoopEmailClient.kt
+++ b/src/main/kotlin/com/wafflestudio/spring2025/common/email/client/NoopEmailClient.kt
@@ -1,0 +1,22 @@
+package com.wafflestudio.spring2025.common.email.client
+
+import org.slf4j.LoggerFactory
+import org.springframework.mail.javamail.JavaMailSender
+import org.springframework.stereotype.Component
+
+@Component
+class NoopEmailClient(
+    private val javaMailSender: JavaMailSender,
+) : EmailClient {
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    override fun sendEmail(
+        to: String,
+        subject: String,
+        htmlContent: String,
+        fromEmail: String,
+        fromName: String,
+    ) {
+        logger.info("메일링 중단으로 발송 생략: $to")
+    }
+}

--- a/src/main/kotlin/com/wafflestudio/spring2025/common/email/service/EmailService.kt
+++ b/src/main/kotlin/com/wafflestudio/spring2025/common/email/service/EmailService.kt
@@ -1,16 +1,10 @@
 package com.wafflestudio.spring2025.common.email.service
 
-import com.wafflestudio.spring2025.common.email.exception.EmailErrorCode
-import com.wafflestudio.spring2025.common.email.exception.EmailServiceUnavailableException
+import com.wafflestudio.spring2025.common.email.client.EmailClient
 import com.wafflestudio.spring2025.config.EmailConfig
 import com.wafflestudio.spring2025.domain.registration.model.RegistrationStatus
-import jakarta.mail.MessagingException
-import jakarta.mail.internet.MimeMessage
 import org.slf4j.LoggerFactory
 import org.springframework.core.io.ClassPathResource
-import org.springframework.mail.MailException
-import org.springframework.mail.javamail.JavaMailSender
-import org.springframework.mail.javamail.MimeMessageHelper
 import org.springframework.stereotype.Service
 import java.nio.charset.StandardCharsets
 import java.time.Instant
@@ -19,8 +13,8 @@ import java.time.format.DateTimeFormatter
 
 @Service
 class EmailService(
-    private val javaMailSender: JavaMailSender,
     private val emailConfig: EmailConfig,
+    private val emailClient: EmailClient,
 ) {
     private val logger = LoggerFactory.getLogger(javaClass)
 
@@ -52,24 +46,13 @@ class EmailService(
         subject: String,
         htmlContent: String,
     ) {
-        try {
-            val message: MimeMessage = javaMailSender.createMimeMessage()
-            val helper = MimeMessageHelper(message, "UTF-8")
-
-            helper.setTo(to)
-            helper.setSubject(subject)
-            helper.setText(htmlContent, true)
-            helper.setFrom("${emailConfig.fromName} <${emailConfig.fromEmail}>")
-
-            // AWS SES 샌드박스 모드에서는 발신/수신 주소 모두 사전 인증(Verified)이 필요합니다.
-            javaMailSender.send(message)
-        } catch (e: MessagingException) {
-            logger.error("메일 구성 실패: to={}, subject={}", to, subject, e)
-            throw EmailServiceUnavailableException(EmailErrorCode.EMAIL_SERVICE_UNAVAILABLE)
-        } catch (e: MailException) {
-            logger.error("메일 전송 실패: to={}, subject={}", to, subject, e)
-            throw EmailServiceUnavailableException(EmailErrorCode.EMAIL_SERVICE_UNAVAILABLE)
-        }
+        emailClient.sendEmail(
+            to = to,
+            subject = subject,
+            htmlContent = htmlContent,
+            fromEmail = emailConfig.fromEmail,
+            fromName = emailConfig.fromName,
+        )
     }
 
     /**


### PR DESCRIPTION
## ✨ Feature PR (to dev)

### 🧪 로컬 테스트 여부 (작업자 체크)
- [x] 로컬에서 Swagger 혹은 테스트 코드로 동작을 확인했습니다.

### 📄 documentation 최신화 여부
> 변경사항과 관련된 API의 swagger documentation이 실제 동작과 일치하는지 확인합니다.
- [ ] (작업자) 확인하였습니다.
- [ ] (리뷰어) 확인하였습니다.

### 📌 작업 내용(what & why)

- 맨 처음에 설계했던 대로 EmailService가 EmailClient 인터페이스에만 의존하도록 복구하였습니다.
  - 중간에 EmailService가 JavaMailSender를 직접 주입받도록 변경되었었는데, 이 의존성을 다시 없앴습니다.
  - 이렇게 변경한 이유는 메일링 서비스를 교체할 때 (예를 들면 저희는 이제 곧 OCI로 이전 예정) 서비스 코드를 건드리지 않고 구현체만 수정할 수 있도록 하기 위함입니다.
- JavaMailEmailClient는 현재 EmailClient의 primary 구현체입니다(Primary 어노테이션을 달아놓았기 때문에, EmailClient 의존성 주입 시 기본적으로 JavaMailEmailClient 구현체가 선택됩니다.)
  - 참고: 현 코드에서는 AWS SES의 SDK를 쓰지 않고 JavaMailSender를 이용해 SMTP 방식으로 SES를 이용 중입니다. (어차피 OCI로 이전 예정이어서 그냥 그대로 두었습니다 - 이전 후에는 OCIEmailClient가 primary가 될 예정입니다)
- NoopEmailClient는 로그만 남기고 실제 이메일을 발송하지 않는 no-op 클라이언트입니다. 혹시나 나중에 이메일 서비스를 잠시 중단해야 할 일이 생긴다면 이 클라이언트를 Primary로 지정하면 됩니다.

### 🔥 관련 이슈
- closes #172
