### PR TITLE
:label: event response에 대기, 참여자 필드 추가 및 전체 신청자 필드 제거

### DIFF
--- a/src/main/kotlin/com/wafflestudio/spring2025/domain/event/dto/response/EventDetailResponse.kt
+++ b/src/main/kotlin/com/wafflestudio/spring2025/domain/event/dto/response/EventDetailResponse.kt
@@ -33,8 +33,10 @@ data class EventInfo(
     val endsAt: Instant?,
     @Schema(description = "정원", example = "10", nullable = true)
     val capacity: Int?,
-    @Schema(description = "총 신청자 수(확정+대기 등)", example = "8")
-    val totalApplicants: Int,
+    @Schema(description = "참여자 수(참여 확정 인원)", example = "5")
+    val confirmedCount: Int,
+    @Schema(description = "대기자 수", example = "5")
+    val waitlistCount: Int,
     @Schema(description = "신청 시작 시간 (ISO-8601)", example = "2026-02-02T17:00:00Z", nullable = true)
     val registrationStartsAt: Instant?,
     @Schema(description = "신청 마감 시간 (ISO-8601)", example = "2026-02-02T17:00:00Z")

--- a/src/main/kotlin/com/wafflestudio/spring2025/domain/event/dto/response/MyEventsInfiniteResponse.kt
+++ b/src/main/kotlin/com/wafflestudio/spring2025/domain/event/dto/response/MyEventsInfiniteResponse.kt
@@ -16,5 +16,6 @@ data class MyEventResponse(
     val registrationStartsAt: Instant?,
     val registrationEndsAt: Instant,
     val capacity: Int?,
-    val totalApplicants: Int,
+    val confirmedCount: Int,
+    val waitlistCount: Int,
 )

--- a/src/main/kotlin/com/wafflestudio/spring2025/domain/event/service/EventService.kt
+++ b/src/main/kotlin/com/wafflestudio/spring2025/domain/event/service/EventService.kt
@@ -228,7 +228,8 @@ class EventService(
                     startsAt = event.startsAt,
                     endsAt = event.endsAt,
                     capacity = event.capacity,
-                    totalApplicants = totalApplicants,
+                    confirmedCount = confirmedCount,
+                    waitlistCount = waitlistedCount,
                     registrationStartsAt = event.registrationStartsAt,
                     registrationEndsAt = event.registrationEndsAt,
                 ),
@@ -297,7 +298,8 @@ class EventService(
                     registrationStartsAt = event.registrationStartsAt,
                     registrationEndsAt = event.registrationEndsAt,
                     capacity = event.capacity,
-                    totalApplicants = confirmedCount + waitlistedCount,
+                    confirmedCount = confirmedCount,
+                    waitlistCount = waitlistedCount,
                 )
             }
 

--- a/src/test/kotlin/com/wafflestudio/spring2025/EventIntegrationTest.kt
+++ b/src/test/kotlin/com/wafflestudio/spring2025/EventIntegrationTest.kt
@@ -357,7 +357,8 @@ class EventIntegrationTest
                 .andExpect(jsonPath("$.event.publicId").value(event.publicId))
                 .andExpect(jsonPath("$.event.title").value("공개 이벤트"))
                 .andExpect(jsonPath("$.event.capacity").value(10))
-                .andExpect(jsonPath("$.event.totalApplicants").value(0))
+                .andExpect(jsonPath("$.event.confirmedCount").value(0))
+                .andExpect(jsonPath("$.event.waitlistCount").value(0))
                 .andExpect(jsonPath("$.creator.name").value(creator.name))
                 .andExpect(jsonPath("$.creator.email").value(creator.email))
                 .andExpect(jsonPath("$.viewer.status").value("NONE"))
@@ -536,7 +537,7 @@ class EventIntegrationTest
         }
 
         @Test
-        fun `totalApplicants는 CONFIRMED + WAITLISTED 수의 합이다`() {
+        fun `confirmedCnt는 참여자(확정) 수를 반영한다`() {
             val (creator, _) = dataGenerator.generateUser()
             val (user1, _) = dataGenerator.generateUser()
             val (user2, _) = dataGenerator.generateUser()
@@ -550,7 +551,25 @@ class EventIntegrationTest
                 .perform(
                     get("/api/events/${event.publicId}"),
                 ).andExpect(status().isOk)
-                .andExpect(jsonPath("$.event.totalApplicants").value(3))
+                .andExpect(jsonPath("$.event.confirmedCount").value(2))
+        }
+
+        @Test
+        fun `waitlistCount는 대기자 수를 반영한다`() {
+            val (creator, _) = dataGenerator.generateUser()
+            val (user1, _) = dataGenerator.generateUser()
+            val (user2, _) = dataGenerator.generateUser()
+            val event = createEventInDb(createdBy = creator.id!!, capacity = 2, waitlistEnabled = true)
+
+            registrationRepository.save(Registration(userId = creator.id!!, eventId = event.id!!, status = RegistrationStatus.CONFIRMED))
+            registrationRepository.save(Registration(userId = user1.id!!, eventId = event.id!!, status = RegistrationStatus.CONFIRMED))
+            registrationRepository.save(Registration(userId = user2.id!!, eventId = event.id!!, status = RegistrationStatus.WAITLISTED))
+
+            mvc
+                .perform(
+                    get("/api/events/${event.publicId}"),
+                ).andExpect(status().isOk)
+                .andExpect(jsonPath("$.event.waitlistCount").value(1))
         }
 
         // =================================================================
@@ -627,7 +646,8 @@ class EventIntegrationTest
                 .andExpect(jsonPath("$.events[0].publicId").value(event.publicId))
                 .andExpect(jsonPath("$.events[0].title").value("필드 검증 이벤트"))
                 .andExpect(jsonPath("$.events[0].capacity").value(20))
-                .andExpect(jsonPath("$.events[0].totalApplicants").value(0))
+                .andExpect(jsonPath("$.events[0].confirmedCount").value(0))
+                .andExpect(jsonPath("$.events[0].waitlistCount").value(0))
         }
 
         @Test


### PR DESCRIPTION
## ✨ Feature PR (to dev)

### 🧪 로컬 테스트 여부 (작업자 체크)
- [x] 로컬에서 Swagger 혹은 테스트 코드로 동작을 확인했습니다.

### 📄 documentation 최신화 여부
> 변경사항과 관련된 API의 swagger documentation이 실제 동작과 일치하는지 확인합니다.
- [ ] (작업자) 확인하였습니다.
- [ ] (리뷰어) 확인하였습니다.

### 📌 작업 내용(what & why)

- 신청 인원이 3/1 등 직관적이지 않게 표기되는 문제가 있어, GET /api/events/{publicId} 와 GET /api/events/me 에서 참여자 수와 대기자 수를 분리하여 응답하도록 변경하였습니다. (기존의 전체 신청자 수 필드는 삭제)
- EventIntegrationTest에서 관련 테스트케이스들도 수정하였습니다.

### 🔎 영향 범위
  <!-- 해당하는 항목만 남기고 나머지는 삭제해주세요 -->                                                                                                                                                                                    
- API 스펙 변경

### 📡 API 변경사항 (있다면)

| Method    | URL | 변경 내용 |
|-----------|-----|----------|
| GET | /events/{publicId} | confirmedCount, waitlistCount 필드 추가 / totalApplicants 필드 삭제 |
| GET | /events/me | confirmedCount, waitlistCount 필드 추가 / totalApplicants 필드 삭제 |

### 🔥 관련 이슈
- closes #231 
