### PR TITLE
:recycle: 메일 템플릿의 하드코딩된 도메인 환경변수 주입으로 변경

### DIFF
--- a/src/main/kotlin/com/wafflestudio/spring2025/common/email/service/EmailService.kt
+++ b/src/main/kotlin/com/wafflestudio/spring2025/common/email/service/EmailService.kt
@@ -133,6 +133,7 @@ class EmailService(
             RegistrationStatus.CONFIRMED -> {
                 val htmlContent =
                     loadTemplate("registration-confirmed.html")
+                        .replace("{serviceDomain}", emailConfig.serviceDomain)
                         .replace("{name}", data.name)
                         .replace("{eventTitle}", formatEventTitle(data.eventTitle))
                         .replace("{eventDateRange}", formatEventDateRange(data.startsAt, data.endsAt, "-"))
@@ -158,6 +159,7 @@ class EmailService(
             RegistrationStatus.WAITLISTED -> {
                 val htmlContent =
                     loadTemplate("registration-waitlisted.html")
+                        .replace("{serviceDomain}", emailConfig.serviceDomain)
                         .replace("{name}", data.name)
                         .replace("{waitingNum}", data.waitingNum?.toString() ?: "-")
                         .replace("{eventTitle}", formatEventTitle(data.eventTitle))
@@ -253,6 +255,7 @@ class EmailService(
     fun sendDemotionEmail(data: DemotionEmailData) {
         val htmlContent =
             loadTemplate("registration-demoted.html")
+                .replace("{serviceDomain}", emailConfig.serviceDomain)
                 .replace("{name}", data.name)
                 .replace("{waitingNum}", data.waitingNum?.toString() ?: "-")
                 .replace("{newCapacity}", data.newCapacity.toString())
@@ -293,6 +296,7 @@ class EmailService(
     ) {
         val htmlContent =
             loadTemplate("registration-waitlist-promoted.html")
+                .replace("{serviceDomain}", emailConfig.serviceDomain)
                 .replace("{name}", name)
                 .replace("{waitingNum}", waitingNum?.toString() ?: "-")
                 .replace("{eventTitle}", formatEventTitle(eventTitle))

--- a/src/main/resources/com/wafflestudio/spring2025/common/email/template/registration-confirmed.html
+++ b/src/main/resources/com/wafflestudio/spring2025/common/email/template/registration-confirmed.html
@@ -99,7 +99,7 @@
             style="font-size: 16px; line-height: 1.7; color: #333; margin-bottom: 50px; white-space: wrap; word-break: break-all;">
             {description}</div>
 
-        <a href="https://www.moiming.app/event/{publicId}?regId={registrationPublicId}"
+        <a href="{serviceDomain}/event/{publicId}?regId={registrationPublicId}"
             style="display: block; width: 100%; padding: 18px 0; background-color: #FEE9E7; border: 1px solid #900B09; border-radius: 10px; color: #900B09; font-size: 17px; font-weight: 600; text-align: center; text-decoration: none;">
             취소하기
         </a>

--- a/src/main/resources/com/wafflestudio/spring2025/common/email/template/registration-demoted.html
+++ b/src/main/resources/com/wafflestudio/spring2025/common/email/template/registration-demoted.html
@@ -108,7 +108,7 @@
                     style="font-size: 16px; line-height: 1.7; color: #333; margin-bottom: 50px; white-space: wrap; word-break: break-all;">
                     {description}</div>
 
-                <a href="https://www.moiming.app/event/{publicId}?regId={registrationPublicId}"
+                <a href="{serviceDomain}/event/{publicId}?regId={registrationPublicId}"
                     style="display: block; width: 100%; padding: 18px 0; background-color: #FEE9E7; border: 1px solid #900B09; border-radius: 10px; color: #900B09; font-size: 17px; font-weight: 600; text-align: center; text-decoration: none;">
                     취소하기
                 </a>

--- a/src/main/resources/com/wafflestudio/spring2025/common/email/template/registration-waitlist-promoted.html
+++ b/src/main/resources/com/wafflestudio/spring2025/common/email/template/registration-waitlist-promoted.html
@@ -99,7 +99,7 @@
             style="font-size: 16px; line-height: 1.7; color: #333; margin-bottom: 50px; white-space: wrap; word-break: break-all;">
             {description}</div>
 
-        <a href="https://www.moiming.app/event/{publicId}?regId={registrationPublicId}"
+        <a href="{serviceDomain}/event/{publicId}?regId={registrationPublicId}"
             style="display: block; width: 100%; padding: 18px 0; background-color: #FEE9E7; border: 1px solid #900B09; border-radius: 10px; color: #900B09; font-size: 17px; font-weight: 600; text-align: center; text-decoration: none;">
             취소하기
         </a>

--- a/src/main/resources/com/wafflestudio/spring2025/common/email/template/registration-waitlisted.html
+++ b/src/main/resources/com/wafflestudio/spring2025/common/email/template/registration-waitlisted.html
@@ -108,7 +108,7 @@
                     style="font-size: 16px; line-height: 1.7; color: #333; margin-bottom: 50px; white-space: wrap; word-break: break-all;">
                     {description}</div>
 
-                <a href="https://www.moiming.app/event/{publicId}?regId={registrationPublicId}"
+                <a href="{serviceDomain}/event/{publicId}?regId={registrationPublicId}"
                     style="display: block; width: 100%; padding: 18px 0; background-color: #FEE9E7; border: 1px solid #900B09; border-radius: 10px; color: #900B09; font-size: 17px; font-weight: 600; text-align: center; text-decoration: none;">
                     취소하기
                 </a>


### PR DESCRIPTION
## ✨ Feature PR (to dev)

### 🧪 로컬 테스트 여부 (작업자 체크)
- [x] 로컬에서 Swagger 혹은 테스트 코드로 동작을 확인했습니다.

### 📄 documentation 최신화 여부
> 변경사항과 관련된 API의 swagger documentation이 실제 동작과 일치하는지 확인합니다.
- [ ] (작업자) 확인하였습니다.
- [ ] (리뷰어) 확인하였습니다.

### 📌 작업 내용(what & why)

- 메일 템플릿에 www.moiming.app으로 하드코딩되어있던 도메인 url을 환경변수로부터 주입받도록 변경하였습니다.
- OCI vault에 들어 있는 email.service-domain 값으로 자동 대치됩니다.


### 🔥 관련 이슈
- closes #235 
