### PR TITLE
refactor(openapi): migrate from swagger annotations to static openapi.yaml

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/dev.md
+++ b/.github/PULL_REQUEST_TEMPLATE/dev.md
@@ -2,6 +2,8 @@
 
 ### 🧪 로컬 테스트 여부 (작업자 체크)
 - [ ] 로컬에서 Swagger 혹은 테스트 코드로 동작을 확인했습니다.
+- [ ] API 변경이 있다면 `src/main/resources/static/docs/openapi.yaml`을 함께 갱신했습니다.
+- [ ] `/docs/swagger-ui.html`에서 변경 API가 의도대로 보이는지 확인했습니다.
 
 ### 📄 documentation 최신화 여부
 > 변경사항과 관련된 API의 swagger documentation이 실제 동작과 일치하는지 확인합니다.

--- a/.github/PULL_REQUEST_TEMPLATE/main.md
+++ b/.github/PULL_REQUEST_TEMPLATE/main.md
@@ -5,6 +5,7 @@
 - [ ] CI 성공
 - [ ] 환경 변수 설정 확인
 - [ ] dev 서버에서 변경사항에 대해 의도대로 동작함을 확인
+- [ ] API 변경이 있다면 `src/main/resources/static/docs/openapi.yaml` 반영 완료
 
 ### 📝 업데이트 사항 요약
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,14 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Set up Node 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Lint OpenAPI YAML
+        run: npx @redocly/cli@latest lint src/main/resources/static/docs/openapi.yaml
+
       - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:

--- a/src/main/kotlin/com/wafflestudio/spring2025/common/image/controller/ImageController.kt
+++ b/src/main/kotlin/com/wafflestudio/spring2025/common/image/controller/ImageController.kt
@@ -4,10 +4,6 @@ import com.wafflestudio.spring2025.common.image.dto.ImageUploadResponse
 import com.wafflestudio.spring2025.common.image.service.ImageService
 import com.wafflestudio.spring2025.domain.auth.LoggedInUser
 import com.wafflestudio.spring2025.domain.user.model.User
-import io.swagger.v3.oas.annotations.Operation
-import io.swagger.v3.oas.annotations.Parameter
-import io.swagger.v3.oas.annotations.responses.ApiResponse
-import io.swagger.v3.oas.annotations.responses.ApiResponses
 import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.PostMapping
@@ -22,21 +18,12 @@ import org.springframework.web.multipart.MultipartFile
 class ImageController(
     private val imageService: ImageService,
 ) {
-    @Operation(summary = "이미지 업로드", description = "서버 저장소에 이미지를 업로드합니다.")
-    @ApiResponses(
-        value = [
-            ApiResponse(responseCode = "200", description = "이미지 업로드 성공"),
-            ApiResponse(responseCode = "400", description = "잘못된 요청 (파일 누락/형식 오류 등)"),
-            ApiResponse(responseCode = "401", description = "인증 실패 (유효하지 않은 토큰)"),
-        ],
-    )
     @PostMapping(
         consumes = [MediaType.MULTIPART_FORM_DATA_VALUE],
     )
     fun uploadImage(
-        @Parameter(hidden = true) @LoggedInUser user: User?,
+        @LoggedInUser user: User?,
         @RequestPart("image") image: MultipartFile,
-        @Parameter(description = "이미지를 저장할 상위 경로", required = false)
         @RequestParam(name = "prefix", required = false)
         prefix: String?,
     ): ResponseEntity<ImageUploadResponse> {

--- a/src/main/kotlin/com/wafflestudio/spring2025/domain/auth/controller/AuthController.kt
+++ b/src/main/kotlin/com/wafflestudio/spring2025/domain/auth/controller/AuthController.kt
@@ -5,10 +5,6 @@ import com.wafflestudio.spring2025.domain.auth.dto.LoginResponse
 import com.wafflestudio.spring2025.domain.auth.dto.SignupRequest
 import com.wafflestudio.spring2025.domain.auth.service.AuthService
 import com.wafflestudio.spring2025.domain.auth.service.EmailVerificationService
-import io.swagger.v3.oas.annotations.Operation
-import io.swagger.v3.oas.annotations.responses.ApiResponse
-import io.swagger.v3.oas.annotations.responses.ApiResponses
-import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.servlet.http.HttpServletRequest
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.PathVariable
@@ -19,23 +15,10 @@ import org.springframework.web.bind.annotation.RestController
 
 @RestController
 @RequestMapping("/api/auth")
-@Tag(name = "Auth", description = "인증 API")
 class AuthController(
     private val authService: AuthService,
     private val emailVerificationService: EmailVerificationService,
 ) {
-    @Operation(
-        summary = "이메일 회원가입",
-        description = "새로운 사용자를 등록하고 인증 이메일을 발송합니다. 이메일 인증 후 가입이 완료됩니다.",
-    )
-    @ApiResponses(
-        value = [
-            ApiResponse(responseCode = "204", description = "인증 이메일 발송 성공"),
-            ApiResponse(responseCode = "400", description = "잘못된 요청 (유효하지 않은 email/password/name)"),
-            ApiResponse(responseCode = "409", description = "이미 존재하는 email"),
-            ApiResponse(responseCode = "503", description = "이메일 서비스 장애"),
-        ],
-    )
     @PostMapping("/signup")
     fun signup(
         @RequestBody signupRequest: SignupRequest,
@@ -51,16 +34,6 @@ class AuthController(
         return ResponseEntity.noContent().build()
     }
 
-    @Operation(
-        summary = "이메일 인증",
-        description = "이메일로 받은 인증 코드를 검증하고 회원가입을 완료합니다",
-    )
-    @ApiResponses(
-        value = [
-            ApiResponse(responseCode = "200", description = "인증 성공, 유저 등록 완료"),
-            ApiResponse(responseCode = "400", description = "유효하지 않거나 만료된 인증 코드"),
-        ],
-    )
     @PostMapping("/email-verification/{verificationCode}")
     fun verifyEmail(
         @PathVariable verificationCode: String,
@@ -69,13 +42,6 @@ class AuthController(
         return ResponseEntity.ok().build()
     }
 
-    @Operation(summary = "로그인", description = "email로 로그인하여 JWT 토큰을 발급받습니다")
-    @ApiResponses(
-        value = [
-            ApiResponse(responseCode = "200", description = "로그인 성공, JWT 토큰 반환"),
-            ApiResponse(responseCode = "401", description = "인증 실패"),
-        ],
-    )
     @PostMapping("/login")
     fun login(
         @RequestBody loginRequest: LoginRequest,
@@ -84,12 +50,6 @@ class AuthController(
         return ResponseEntity.ok(LoginResponse(token))
     }
 
-    @Operation(summary = "로그아웃", description = "현재 JWT 토큰을 블랙리스트에 추가하여 로그아웃합니다")
-    @ApiResponses(
-        value = [
-            ApiResponse(responseCode = "204", description = "로그아웃 성공"),
-        ],
-    )
     @PostMapping("/logout")
     fun logout(request: HttpServletRequest): ResponseEntity<Void> {
         val token = resolveToken(request)

--- a/src/main/kotlin/com/wafflestudio/spring2025/domain/auth/controller/SocialAuthController.kt
+++ b/src/main/kotlin/com/wafflestudio/spring2025/domain/auth/controller/SocialAuthController.kt
@@ -4,9 +4,6 @@ import com.wafflestudio.spring2025.domain.auth.dto.LoginResponse
 import com.wafflestudio.spring2025.domain.auth.dto.SocialLoginRequest
 import com.wafflestudio.spring2025.domain.auth.model.SocialProvider
 import com.wafflestudio.spring2025.domain.auth.service.SocialAuthService
-import io.swagger.v3.oas.annotations.Operation
-import io.swagger.v3.oas.annotations.responses.ApiResponse
-import io.swagger.v3.oas.annotations.responses.ApiResponses
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
@@ -18,14 +15,6 @@ import org.springframework.web.bind.annotation.RestController
 class SocialAuthController(
     private val socialAuthService: SocialAuthService,
 ) {
-    @Operation(summary = "소셜 로그인", description = "소셜 로그인을 요청합니다.")
-    @ApiResponses(
-        value = [
-            ApiResponse(responseCode = "200", description = "소셜 로그인 성공"),
-            ApiResponse(responseCode = "401", description = "인증 실패"),
-            ApiResponse(responseCode = "409", description = "이미 가입된 이메일"),
-        ],
-    )
     @PostMapping
     suspend fun social(
         @RequestBody socialLoginRequest: SocialLoginRequest,

--- a/src/main/kotlin/com/wafflestudio/spring2025/domain/auth/controller/SocialAuthController.kt
+++ b/src/main/kotlin/com/wafflestudio/spring2025/domain/auth/controller/SocialAuthController.kt
@@ -11,7 +11,7 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
-@RequestMapping("api/auth/social")
+@RequestMapping("/api/auth/social")
 class SocialAuthController(
     private val socialAuthService: SocialAuthService,
 ) {

--- a/src/main/kotlin/com/wafflestudio/spring2025/domain/auth/dto/LoginRequest.kt
+++ b/src/main/kotlin/com/wafflestudio/spring2025/domain/auth/dto/LoginRequest.kt
@@ -1,11 +1,6 @@
 package com.wafflestudio.spring2025.domain.auth.dto
 
-import io.swagger.v3.oas.annotations.media.Schema
-
-@Schema(description = "로그인 요청")
 data class LoginRequest(
-    @Schema(description = "사용자 이메일", example = "user@example.com", required = true)
     val email: String,
-    @Schema(description = "사용자 비밀번호", example = "mypassword", required = true)
     val password: String,
 )

--- a/src/main/kotlin/com/wafflestudio/spring2025/domain/auth/dto/RegisterRequest.kt
+++ b/src/main/kotlin/com/wafflestudio/spring2025/domain/auth/dto/RegisterRequest.kt
@@ -1,8 +1,0 @@
-package com.wafflestudio.spring2025.domain.auth.dto
-
-data class RegisterRequest(
-    val email: String,
-    val name: String,
-    val password: String,
-    val profileImage: String? = null,
-)

--- a/src/main/kotlin/com/wafflestudio/spring2025/domain/auth/dto/RegisterRequest.kt
+++ b/src/main/kotlin/com/wafflestudio/spring2025/domain/auth/dto/RegisterRequest.kt
@@ -1,15 +1,8 @@
 package com.wafflestudio.spring2025.domain.auth.dto
 
-import io.swagger.v3.oas.annotations.media.Schema
-
-@Schema(description = "회원가입 요청")
 data class RegisterRequest(
-    @Schema(description = "사용자 이메일", example = "user@example.com", required = true)
     val email: String,
-    @Schema(description = "사용자 이름", example = "홍길동", required = true)
     val name: String,
-    @Schema(description = "비밀번호", example = "password123", required = true)
     val password: String,
-    @Schema(description = "프로필 이미지 URL", example = "https://cdn.example.com/profile.png")
     val profileImage: String? = null,
 )

--- a/src/main/kotlin/com/wafflestudio/spring2025/domain/auth/dto/SignupRequest.kt
+++ b/src/main/kotlin/com/wafflestudio/spring2025/domain/auth/dto/SignupRequest.kt
@@ -1,15 +1,8 @@
 package com.wafflestudio.spring2025.domain.auth.dto
 
-import io.swagger.v3.oas.annotations.media.Schema
-
-@Schema(description = "회원가입 요청")
 data class SignupRequest(
-    @Schema(description = "사용자 이메일", example = "user@example.com", required = true)
     val email: String,
-    @Schema(description = "사용자 이름", example = "홍길동", required = true)
     val name: String,
-    @Schema(description = "비밀번호", example = "password123", required = true)
     val password: String,
-    @Schema(description = "프로필 이미지 URL", example = "https://cdn.example.com/profile.png")
     val profileImage: String? = null,
 )

--- a/src/main/kotlin/com/wafflestudio/spring2025/domain/auth/dto/SocialLoginRequest.kt
+++ b/src/main/kotlin/com/wafflestudio/spring2025/domain/auth/dto/SocialLoginRequest.kt
@@ -1,11 +1,6 @@
 package com.wafflestudio.spring2025.domain.auth.dto
 
-import io.swagger.v3.oas.annotations.media.Schema
-
-@Schema(description = "소셜 로그인 요청")
 data class SocialLoginRequest(
-    @Schema(description = "소셜로그인 제공자", example = "GOOGLE", required = true)
     val provider: String,
-    @Schema(description = "인가 코드 (authorization code)", required = true)
     val code: String,
 )

--- a/src/main/kotlin/com/wafflestudio/spring2025/domain/event/controller/EventController.kt
+++ b/src/main/kotlin/com/wafflestudio/spring2025/domain/event/controller/EventController.kt
@@ -10,8 +10,6 @@ import com.wafflestudio.spring2025.domain.event.dto.response.MyEventsInfiniteRes
 import com.wafflestudio.spring2025.domain.event.dto.response.UpdateEventResponse
 import com.wafflestudio.spring2025.domain.event.service.EventService
 import com.wafflestudio.spring2025.domain.user.model.User
-import io.swagger.v3.oas.annotations.Operation
-import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
@@ -26,12 +24,10 @@ import java.time.Instant
 
 @RestController
 @RequestMapping("/api/events")
-@Tag(name = "Event", description = "이벤트 관리 API")
 class EventController(
     private val eventService: EventService,
 ) {
     @AuthRequired
-    @Operation(summary = "이벤트 생성", description = "새로운 이벤트를 생성합니다")
     @PostMapping // POST /api/events
     fun create(
         @LoggedInUser user: User,
@@ -54,7 +50,6 @@ class EventController(
         return ResponseEntity.ok(CreateEventResponse(publicId))
     }
 
-    @Operation(summary = "이벤트 상세 조회", description = "이벤트 상세 정보를 조회합니다")
     @GetMapping("/{publicId}") // GET /api/events/{publicId}
     fun getById(
         @LoggedInUser user: User?, // nullable
@@ -69,10 +64,6 @@ class EventController(
     }
 
     @AuthRequired
-    @Operation(
-        summary = "내가 만든 이벤트 목록 조회 (무한 스크롤)",
-        description = "로그인된 사용자가 생성한 이벤트 목록을 무한 스크롤 방식(cursor)으로 조회합니다",
-    )
     @GetMapping("/me")
     fun getMyEvents(
         @LoggedInUser user: User,
@@ -89,7 +80,6 @@ class EventController(
     }
 
     @AuthRequired
-    @Operation(summary = "이벤트 수정", description = "이벤트를 수정합니다")
     @PutMapping("/{publicId}") // PUT /api/events/{publicId}
     fun update(
         @LoggedInUser user: User,
@@ -116,7 +106,6 @@ class EventController(
     }
 
     @AuthRequired
-    @Operation(summary = "이벤트 삭제", description = "이벤트를 삭제합니다")
     @DeleteMapping("/{publicId}") // DELETE /api/events/{publicId}
     fun delete(
         @LoggedInUser user: User,

--- a/src/main/kotlin/com/wafflestudio/spring2025/domain/event/dto/core/EventDto.kt
+++ b/src/main/kotlin/com/wafflestudio/spring2025/domain/event/dto/core/EventDto.kt
@@ -1,35 +1,20 @@
 package com.wafflestudio.spring2025.domain.event.dto.core
 
 import com.wafflestudio.spring2025.domain.event.model.Event
-import io.swagger.v3.oas.annotations.media.Schema
 
-@Schema(description = "일정 정보")
 data class EventDto(
-    @Schema(description = "일정 ID (publicId)")
     val id: String,
-    @Schema(description = "이벤트 제목")
     val title: String,
-    @Schema(description = "이벤트 설명")
     val description: String?,
-    @Schema(description = "장소")
     val location: String?,
-    @Schema(description = "시작 시간 (epoch milliseconds)")
     val startsAt: Long?,
-    @Schema(description = "종료 시간 (epoch milliseconds)")
     val endsAt: Long?,
-    @Schema(description = "정원")
     val capacity: Int?,
-    @Schema(description = "대기 명단 사용 여부")
     val waitlistEnabled: Boolean,
-    @Schema(description = "신청 시작 시간 (epoch milliseconds)")
     val registrationStartsAt: Long?,
-    @Schema(description = "신청 마감 시간 (epoch milliseconds)")
     val registrationEndsAt: Long,
-    @Schema(description = "작성자 ID")
     val createdBy: Long,
-    @Schema(description = "생성 일시 (epoch milliseconds)")
     val createdAt: Long?,
-    @Schema(description = "수정 일시 (epoch milliseconds)")
     val updatedAt: Long?,
 ) {
     constructor(event: Event) : this(

--- a/src/main/kotlin/com/wafflestudio/spring2025/domain/event/dto/request/CreateEventRequest.kt
+++ b/src/main/kotlin/com/wafflestudio/spring2025/domain/event/dto/request/CreateEventRequest.kt
@@ -1,38 +1,15 @@
 package com.wafflestudio.spring2025.domain.event.dto.request
 
-import io.swagger.v3.oas.annotations.media.Schema
 import java.time.Instant
 
-@Schema(description = "일정 생성 요청")
 data class CreateEventRequest(
-    @Schema(description = "이벤트 제목", example = "정기 모임")
     val title: String,
-    @Schema(description = "이벤트 설명", example = "정기 모임입니다")
     val description: String? = null,
-    @Schema(description = "장소", example = "강의실 101")
     val location: String? = null,
-    @Schema(
-        description = "시작 시간 (ISO-8601)",
-        example = "2026-02-02T18:00:00Z",
-    )
     val startsAt: Instant? = null,
-    @Schema(
-        description = "종료 시간 (ISO-8601)",
-        example = "2026-02-02T20:00:00Z",
-    )
     val endsAt: Instant? = null,
-    @Schema(description = "정원", example = "30")
     val capacity: Int,
-    @Schema(description = "대기 명단 사용 여부", example = "true")
     val waitlistEnabled: Boolean,
-    @Schema(
-        description = "신청 시작 시간 (ISO-8601). null인 경우 요청 시점으로 자동 설정됩니다.",
-        example = "2026-02-02T17:00:00Z",
-    )
     val registrationStartsAt: Instant? = null,
-    @Schema(
-        description = "신청 마감 시간 (ISO-8601)",
-        example = "2026-02-02T17:30:00Z",
-    )
     val registrationEndsAt: Instant,
 )

--- a/src/main/kotlin/com/wafflestudio/spring2025/domain/event/dto/request/UpdateEventRequest.kt
+++ b/src/main/kotlin/com/wafflestudio/spring2025/domain/event/dto/request/UpdateEventRequest.kt
@@ -1,38 +1,15 @@
 package com.wafflestudio.spring2025.domain.event.dto.request
 
-import io.swagger.v3.oas.annotations.media.Schema
 import java.time.Instant
 
-@Schema(description = "일정 수정 요청")
 data class UpdateEventRequest(
-    @Schema(description = "이벤트 제목", example = "정기 모임")
     val title: String? = null,
-    @Schema(description = "이벤트 설명", example = "정기 모임입니다")
     val description: String? = null,
-    @Schema(description = "장소", example = "강의실 101")
     val location: String? = null,
-    @Schema(
-        description = "시작 시간 (ISO-8601)",
-        example = "2026-02-02T18:00:00Z",
-    )
     val startsAt: Instant? = null,
-    @Schema(
-        description = "종료 시간 (ISO-8601)",
-        example = "2026-02-02T20:00:00Z",
-    )
     val endsAt: Instant? = null,
-    @Schema(description = "정원", example = "30")
     val capacity: Int? = null,
-    @Schema(description = "대기 명단 사용 여부", example = "true")
     val waitlistEnabled: Boolean? = null,
-    @Schema(
-        description = "신청 시작 시간 (ISO-8601)",
-        example = "2026-02-02T17:00:00Z",
-    )
     val registrationStartsAt: Instant? = null,
-    @Schema(
-        description = "신청 마감 시간 (ISO-8601)",
-        example = "2026-02-02T17:30:00Z",
-    )
     val registrationEndsAt: Instant? = null,
 )

--- a/src/main/kotlin/com/wafflestudio/spring2025/domain/event/dto/response/EventDetailResponse.kt
+++ b/src/main/kotlin/com/wafflestudio/spring2025/domain/event/dto/response/EventDetailResponse.kt
@@ -1,97 +1,45 @@
 package com.wafflestudio.spring2025.domain.event.dto.response
 
-import io.swagger.v3.oas.annotations.media.Schema
 import java.time.Instant
 
-@Schema(description = "일정 상세 조회 응답")
 data class EventDetailResponse(
-    @Schema(description = "이벤트 정보")
     val event: EventInfo,
-    @Schema(description = "이벤트 생성자 정보")
     val creator: CreatorInfo,
-    @Schema(description = "조회자(viewer) 정보")
     val viewer: ViewerInfo,
-    @Schema(description = "조회자가 할 수 있는 동작")
     val capabilities: CapabilitiesInfo,
-    @Schema(description = "참여자 미리보기 목록")
     val guestsPreview: List<GuestPreview>,
 )
 
-@Schema(description = "이벤트 정보 블록")
 data class EventInfo(
-    @Schema(description = "이벤트 publicId", example = "dj8sadj10djnkas")
     val publicId: String,
-    @Schema(description = "이벤트 제목", example = "제2회 기획 세미나")
     val title: String,
-    @Schema(description = "이벤트 설명", example = "일정 상세 설명...", nullable = true)
     val description: String?,
-    @Schema(description = "장소", example = "서울대", nullable = true)
     val location: String?,
-    @Schema(description = "시작 시간 (ISO-8601)", example = "2026-02-02T18:00:00Z", nullable = true)
     val startsAt: Instant?,
-    @Schema(description = "종료 시간 (ISO-8601)", example = "2026-02-02T20:00:00Z", nullable = true)
     val endsAt: Instant?,
-    @Schema(description = "정원", example = "10", nullable = true)
     val capacity: Int?,
-    @Schema(description = "총 신청자 수(확정+대기 등)", example = "8")
     val totalApplicants: Int,
-    @Schema(description = "신청 시작 시간 (ISO-8601)", example = "2026-02-02T17:00:00Z", nullable = true)
     val registrationStartsAt: Instant?,
-    @Schema(description = "신청 마감 시간 (ISO-8601)", example = "2026-02-02T17:00:00Z")
     val registrationEndsAt: Instant,
 )
 
-@Schema(description = "생성자 정보 블록")
 data class CreatorInfo(
-    @Schema(description = "이름", example = "홍길동")
     val name: String,
-    @Schema(description = "이메일", example = "user@example.com")
     val email: String,
-    @Schema(description = "프로필 이미지", example = "https://example.com/profile.png", nullable = true)
     val profileImage: String?,
 )
 
-@Schema(description = "조회자(viewer) 정보 블록")
 data class ViewerInfo(
-    @Schema(
-        description = "viewer의 등록 상태 (RegistrationStatus 사용)",
-        example = "WAITLISTED",
-    )
     val status: ViewerStatus,
-    @Schema(
-        description = "viewer 이름 (비회원이면 null)",
-        example = "홍길동",
-        nullable = true,
-    )
     val name: String?,
-    @Schema(
-        description = "대기 순번 (WAITLISTED일 때만 숫자, 아니면 null)",
-        example = "3",
-        nullable = true,
-    )
     val waitlistPosition: Int?,
-    @Schema(
-        description = "registrationPublicId (게스트면 값, 아니면 null)",
-        example = "1",
-        nullable = true,
-    )
     val registrationPublicId: String?,
-    @Schema(
-        description = "예약 이메일(게스트면 guestEmail, 로그인 유저면 user email 등 정책에 따름)",
-        example = "skdfsj@gmaldkl",
-        nullable = true,
-    )
     val reservationEmail: String?,
 )
 
-@Schema(description = "가능한 동작 블록")
 data class CapabilitiesInfo(
-    @Schema(description = "공유 링크 가능 여부", example = "false")
     val shareLink: Boolean,
-    @Schema(description = "참여 신청 가능 여부(확정 자리 신청)", example = "false")
     val apply: Boolean,
-    @Schema(description = "대기 신청 가능 여부(정원 찼을 때)", example = "false")
     val wait: Boolean,
-    @Schema(description = "신청 취소 가능 여부", example = "true")
     val cancel: Boolean,
 )

--- a/src/main/kotlin/com/wafflestudio/spring2025/domain/event/dto/response/EventDetailResponse.kt
+++ b/src/main/kotlin/com/wafflestudio/spring2025/domain/event/dto/response/EventDetailResponse.kt
@@ -1,99 +1,46 @@
 package com.wafflestudio.spring2025.domain.event.dto.response
 
-import io.swagger.v3.oas.annotations.media.Schema
 import java.time.Instant
 
-@Schema(description = "일정 상세 조회 응답")
 data class EventDetailResponse(
-    @Schema(description = "이벤트 정보")
     val event: EventInfo,
-    @Schema(description = "이벤트 생성자 정보")
     val creator: CreatorInfo,
-    @Schema(description = "조회자(viewer) 정보")
     val viewer: ViewerInfo,
-    @Schema(description = "조회자가 할 수 있는 동작")
     val capabilities: CapabilitiesInfo,
-    @Schema(description = "참여자 미리보기 목록")
     val guestsPreview: List<GuestPreview>,
 )
 
-@Schema(description = "이벤트 정보 블록")
 data class EventInfo(
-    @Schema(description = "이벤트 publicId", example = "dj8sadj10djnkas")
     val publicId: String,
-    @Schema(description = "이벤트 제목", example = "제2회 기획 세미나")
     val title: String,
-    @Schema(description = "이벤트 설명", example = "일정 상세 설명...", nullable = true)
     val description: String?,
-    @Schema(description = "장소", example = "서울대", nullable = true)
     val location: String?,
-    @Schema(description = "시작 시간 (ISO-8601)", example = "2026-02-02T18:00:00Z", nullable = true)
     val startsAt: Instant?,
-    @Schema(description = "종료 시간 (ISO-8601)", example = "2026-02-02T20:00:00Z", nullable = true)
     val endsAt: Instant?,
-    @Schema(description = "정원", example = "10", nullable = true)
     val capacity: Int?,
-    @Schema(description = "참여자 수(참여 확정 인원)", example = "5")
     val confirmedCount: Int,
-    @Schema(description = "대기자 수", example = "5")
     val waitlistCount: Int,
-    @Schema(description = "신청 시작 시간 (ISO-8601)", example = "2026-02-02T17:00:00Z", nullable = true)
     val registrationStartsAt: Instant?,
-    @Schema(description = "신청 마감 시간 (ISO-8601)", example = "2026-02-02T17:00:00Z")
     val registrationEndsAt: Instant,
 )
 
-@Schema(description = "생성자 정보 블록")
 data class CreatorInfo(
-    @Schema(description = "이름", example = "홍길동")
     val name: String,
-    @Schema(description = "이메일", example = "user@example.com")
     val email: String,
-    @Schema(description = "프로필 이미지", example = "https://example.com/profile.png", nullable = true)
     val profileImage: String?,
 )
 
-@Schema(description = "조회자(viewer) 정보 블록")
 data class ViewerInfo(
-    @Schema(
-        description = "viewer의 등록 상태 (RegistrationStatus 사용)",
-        example = "WAITLISTED",
-    )
     val status: ViewerStatus,
-    @Schema(
-        description = "viewer 이름 (비회원이면 null)",
-        example = "홍길동",
-        nullable = true,
-    )
     val name: String?,
-    @Schema(
-        description = "대기 순번 (WAITLISTED일 때만 숫자, 아니면 null)",
-        example = "3",
-        nullable = true,
-    )
     val waitlistPosition: Int?,
-    @Schema(
-        description = "registrationPublicId (게스트면 값, 아니면 null)",
-        example = "1",
-        nullable = true,
-    )
     val registrationPublicId: String?,
-    @Schema(
-        description = "예약 이메일(게스트면 guestEmail, 로그인 유저면 user email 등 정책에 따름)",
-        example = "skdfsj@gmaldkl",
-        nullable = true,
-    )
     val reservationEmail: String?,
 )
 
-@Schema(description = "가능한 동작 블록")
 data class CapabilitiesInfo(
-    @Schema(description = "공유 링크 가능 여부", example = "false")
     val shareLink: Boolean,
-    @Schema(description = "참여 신청 가능 여부(확정 자리 신청)", example = "false")
     val apply: Boolean,
-    @Schema(description = "대기 신청 가능 여부(정원 찼을 때)", example = "false")
     val wait: Boolean,
-    @Schema(description = "신청 취소 가능 여부", example = "true")
     val cancel: Boolean,
 )

--- a/src/main/kotlin/com/wafflestudio/spring2025/domain/event/dto/response/GuestPreview.kt
+++ b/src/main/kotlin/com/wafflestudio/spring2025/domain/event/dto/response/GuestPreview.kt
@@ -1,21 +1,11 @@
 package com.wafflestudio.spring2025.domain.event.dto.response
 
-import io.swagger.v3.oas.annotations.media.Schema
-
 /**
  * 이벤트 참여자 미리보기 정보
  * (회원/비회원 포함)
  */
-@Schema(description = "참여자 미리보기 정보")
 data class GuestPreview(
-    @Schema(description = "참여자 ID (비회원이면 null)", example = "1", nullable = true)
     val id: Long?,
-    @Schema(description = "참여자 이름", example = "홍길동")
     val name: String,
-    @Schema(
-        description = "프로필 이미지 URL",
-        example = "https://example.com/profile.png",
-        nullable = true,
-    )
     val profileImage: String?,
 )

--- a/src/main/kotlin/com/wafflestudio/spring2025/domain/event/dto/response/MyRole.kt
+++ b/src/main/kotlin/com/wafflestudio/spring2025/domain/event/dto/response/MyRole.kt
@@ -1,21 +1,15 @@
 package com.wafflestudio.spring2025.domain.event.dto.response
 
-import io.swagger.v3.oas.annotations.media.Schema
-
 /**
  * 요청자 역할
  * - CREATOR: 이벤트 생성자
  * - PARTICIPANT: 이벤트 참여자 (CONFIRMED / WAITLISTED)
  * - NONE: 로그인은 했지만 참여하지 않음
  */
-@Schema(description = "요청자 역할")
 enum class MyRole {
-    @Schema(description = "이벤트 생성자")
     CREATOR,
 
-    @Schema(description = "이벤트 참여자")
     PARTICIPANT,
 
-    @Schema(description = "이벤트 미참여자")
     NONE,
 }

--- a/src/main/kotlin/com/wafflestudio/spring2025/domain/event/dto/response/ViewerStatus.kt
+++ b/src/main/kotlin/com/wafflestudio/spring2025/domain/event/dto/response/ViewerStatus.kt
@@ -1,25 +1,17 @@
 package com.wafflestudio.spring2025.domain.event.dto.response
 
-import io.swagger.v3.oas.annotations.media.Schema
-
 /**
  * 이벤트 상세 조회 시,
  * "viewer(요청자)"가 해당 이벤트와 어떤 관계에 있는지를 나타내는 상태
  */
-@Schema(description = "이벤트 조회자(Viewer)의 상태")
 enum class ViewerStatus {
-    @Schema(description = "이벤트 생성자")
     HOST,
 
-    @Schema(description = "참여 확정된 사용자")
     CONFIRMED,
 
-    @Schema(description = "대기 중인 사용자")
     WAITLISTED,
 
-    @Schema(description = "강제 취소(차단)된 사용자")
     BANNED,
 
-    @Schema(description = "이벤트와 아무 관계 없는 사용자")
     NONE,
 }

--- a/src/main/kotlin/com/wafflestudio/spring2025/domain/registration/controller/EventRegistrationController.kt
+++ b/src/main/kotlin/com/wafflestudio/spring2025/domain/registration/controller/EventRegistrationController.kt
@@ -6,11 +6,6 @@ import com.wafflestudio.spring2025.domain.registration.dto.response.CreateRegist
 import com.wafflestudio.spring2025.domain.registration.dto.response.GetEventRegistrationsResponse
 import com.wafflestudio.spring2025.domain.registration.service.RegistrationService
 import com.wafflestudio.spring2025.domain.user.model.User
-import io.swagger.v3.oas.annotations.Operation
-import io.swagger.v3.oas.annotations.Parameter
-import io.swagger.v3.oas.annotations.responses.ApiResponse
-import io.swagger.v3.oas.annotations.responses.ApiResponses
-import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -22,35 +17,9 @@ import org.springframework.web.bind.annotation.RestController
 
 @RestController
 @RequestMapping("/api/events/{eventId}/registrations")
-@Tag(name = "Registration", description = "이벤트 기준 신청 API")
 class EventRegistrationController(
     private val registrationService: RegistrationService,
 ) {
-    @Operation(
-        summary = "이벤트 참여 신청",
-        description =
-            "특정 이벤트에 신청합니다. 정원이 남아있으면 CONFIRMED로 등록되고, 정원이 찼으나 대기 명단이 허용된 경우 WAITLISTED로 등록됩니다. " +
-                "정원이 찼고 대기 명단이 비활성화된 경우 신청이 거절됩니다.",
-    )
-    @ApiResponses(
-        value = [
-            ApiResponse(responseCode = "200", description = "신청 성공"),
-            ApiResponse(
-                responseCode = "400",
-                description =
-                    "유효하지 않은 요청: 3003(Wrong guest name), 3004(Wrong guest email), 2204(Invalid registration window)",
-            ),
-            ApiResponse(
-                responseCode = "403",
-                description = "권한 없음: 3006(Banned user cannot register)",
-            ),
-            ApiResponse(responseCode = "404", description = "이벤트 없음: 2001(Event not found)"),
-            ApiResponse(
-                responseCode = "409",
-                description = "신청 불가: 3001(Registration already exists), 3005(Host cannot register), 2301(Event is full)",
-            ),
-        ],
-    )
     @PostMapping
     fun create(
         @PathVariable eventId: String,
@@ -67,17 +36,12 @@ class EventRegistrationController(
         return ResponseEntity.ok(registration)
     }
 
-    @Operation(
-        summary = "이벤트 신청 목록 조회",
-        description = "특정 이벤트에 속한 신청 목록을 조회합니다. 신청 상태(CONFIRMED/WAITLISTED/BANNED)와 신청 시각을 포함해 반환합니다.",
-    )
     @GetMapping
     fun list(
         @PathVariable eventId: String,
         @LoggedInUser user: User?,
         @RequestParam(required = false) status: String?,
         @RequestParam(required = false) orderBy: String?,
-        @Parameter(description = "다음 페이지 시작 offset (없으면 0부터)")
         @RequestParam(required = false) cursor: Int?,
     ): ResponseEntity<GetEventRegistrationsResponse> =
         ResponseEntity.ok(

--- a/src/main/kotlin/com/wafflestudio/spring2025/domain/registration/controller/MyRegistrationController.kt
+++ b/src/main/kotlin/com/wafflestudio/spring2025/domain/registration/controller/MyRegistrationController.kt
@@ -5,9 +5,6 @@ import com.wafflestudio.spring2025.domain.auth.LoggedInUser
 import com.wafflestudio.spring2025.domain.registration.dto.response.GetMyRegistrationsResponse
 import com.wafflestudio.spring2025.domain.registration.service.RegistrationService
 import com.wafflestudio.spring2025.domain.user.model.User
-import io.swagger.v3.oas.annotations.Operation
-import io.swagger.v3.oas.annotations.Parameter
-import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
@@ -17,17 +14,12 @@ import org.springframework.web.bind.annotation.RestController
 @AuthRequired
 @RestController
 @RequestMapping("/api/registrations")
-@Tag(name = "Registration", description = "내 신청 조회 API")
 class MyRegistrationController(
     private val registrationService: RegistrationService,
 ) {
-    @Operation(
-        summary = "내 이벤트 신청 목록 조회",
-        description = "로그인한 사용자의 이벤트 신청 목록을 조회합니다. 최신 신청 순으로 반환되며 page/size로 페이징합니다.",
-    )
     @GetMapping("/me")
     fun myRegistrations(
-        @Parameter(hidden = true) @LoggedInUser user: User,
+        @LoggedInUser user: User,
         @RequestParam(defaultValue = "0") page: Int,
         @RequestParam(defaultValue = "20") size: Int,
     ): ResponseEntity<GetMyRegistrationsResponse> {

--- a/src/main/kotlin/com/wafflestudio/spring2025/domain/registration/controller/RegistrationController.kt
+++ b/src/main/kotlin/com/wafflestudio/spring2025/domain/registration/controller/RegistrationController.kt
@@ -10,8 +10,6 @@ import com.wafflestudio.spring2025.domain.registration.exception.RegistrationErr
 import com.wafflestudio.spring2025.domain.registration.exception.RegistrationValidationException
 import com.wafflestudio.spring2025.domain.registration.service.RegistrationService
 import com.wafflestudio.spring2025.domain.user.model.User
-import io.swagger.v3.oas.annotations.Operation
-import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
@@ -23,16 +21,9 @@ import org.springframework.web.bind.annotation.RestController
 
 @RestController
 @RequestMapping("/api/registrations/{registrationId}")
-@Tag(name = "Registration", description = "신청 단건 리소스 API")
 class RegistrationController(
     private val registrationService: RegistrationService,
 ) {
-    @Operation(
-        summary = "신청 단건 상태 변경",
-        description =
-            "신청 단건 리소스의 상태를 변경합니다. " +
-                "사용자가 본인의 신청을 취소하는 경우와 관리자가 강제 취소/밴 처리하는 경우를 로직 레벨에서 구분합니다.",
-    )
     @PatchMapping
     fun updateStatus(
         @PathVariable registrationId: String,
@@ -45,11 +36,6 @@ class RegistrationController(
         return ResponseEntity.ok(response)
     }
 
-    @Operation(
-        summary = "신청 단건 정보 요청",
-        description =
-            "신청 단건의 정보를 반환합니다.",
-    )
     @GetMapping
     fun getRegistrationInformation(
         @PathVariable registrationId: String,

--- a/src/main/kotlin/com/wafflestudio/spring2025/domain/registration/dto/core/RegistrationDto.kt
+++ b/src/main/kotlin/com/wafflestudio/spring2025/domain/registration/dto/core/RegistrationDto.kt
@@ -2,23 +2,14 @@ package com.wafflestudio.spring2025.domain.registration.dto.core
 
 import com.wafflestudio.spring2025.domain.registration.model.Registration
 import com.wafflestudio.spring2025.domain.registration.model.RegistrationStatus
-import io.swagger.v3.oas.annotations.media.Schema
 
-@Schema(description = "이벤트 신청 정보")
 data class RegistrationDto(
-    @Schema(description = "신청 공개 ID")
     val registrationPublicId: String,
-    @Schema(description = "사용자 ID")
     val userId: Long?,
-    @Schema(description = "이벤트 ID")
     val eventId: Long,
-    @Schema(description = "비회원 이름")
     val guestName: String?,
-    @Schema(description = "비회원 이메일")
     val guestEmail: String?,
-    @Schema(description = "신청 상태")
     val status: RegistrationStatus,
-    @Schema(description = "신청 일시 (epoch milliseconds)")
     val createdAt: Long,
 ) {
     constructor(registration: Registration) : this(

--- a/src/main/kotlin/com/wafflestudio/spring2025/domain/registration/dto/core/RegistrationWithEventDto.kt
+++ b/src/main/kotlin/com/wafflestudio/spring2025/domain/registration/dto/core/RegistrationWithEventDto.kt
@@ -2,13 +2,9 @@ package com.wafflestudio.spring2025.domain.registration.dto.core
 
 import com.wafflestudio.spring2025.domain.event.model.Event
 import com.wafflestudio.spring2025.domain.registration.model.Registration
-import io.swagger.v3.oas.annotations.media.Schema
 
-@Schema(description = "내 이벤트 신청 정보")
 data class RegistrationWithEventDto(
-    @Schema(description = "신청 정보")
     val registration: RegistrationDto,
-    @Schema(description = "이벤트 요약 정보")
     val event: EventSummaryDto,
 ) {
     constructor(registration: Registration, event: Event) : this(
@@ -17,17 +13,11 @@ data class RegistrationWithEventDto(
     )
 }
 
-@Schema(description = "이벤트 요약 정보")
 data class EventSummaryDto(
-    @Schema(description = "이벤트 ID")
     val id: Long,
-    @Schema(description = "이벤트 제목")
     val title: String,
-    @Schema(description = "장소")
     val location: String?,
-    @Schema(description = "시작 시간 (epoch milliseconds)")
     val startsAt: Long?,
-    @Schema(description = "종료 시간 (epoch milliseconds)")
     val endsAt: Long?,
 ) {
     constructor(event: Event) : this(

--- a/src/main/kotlin/com/wafflestudio/spring2025/domain/registration/dto/request/CreateRegistrationRequest.kt
+++ b/src/main/kotlin/com/wafflestudio/spring2025/domain/registration/dto/request/CreateRegistrationRequest.kt
@@ -1,14 +1,10 @@
 package com.wafflestudio.spring2025.domain.registration.dto.request
 
 import com.fasterxml.jackson.annotation.JsonAlias
-import io.swagger.v3.oas.annotations.media.Schema
 
-@Schema(description = "이벤트 신청 요청")
 data class CreateRegistrationRequest(
-    @Schema(description = "비회원 이름")
     @JsonAlias("guest_name")
     val guestName: String? = null,
-    @Schema(description = "비회원 이메일")
     @JsonAlias("guest_email")
     val guestEmail: String? = null,
 )

--- a/src/main/kotlin/com/wafflestudio/spring2025/domain/registration/dto/request/DeleteRegistrationRequest.kt
+++ b/src/main/kotlin/com/wafflestudio/spring2025/domain/registration/dto/request/DeleteRegistrationRequest.kt
@@ -1,11 +1,6 @@
 package com.wafflestudio.spring2025.domain.registration.dto.request
 
-import io.swagger.v3.oas.annotations.media.Schema
-
-@Schema(description = "이벤트 취소 요청")
 data class DeleteRegistrationRequest(
-    @Schema(description = "비회원 이름")
     val guestName: String? = null,
-    @Schema(description = "비회원 이메일")
     val guestEmail: String? = null,
 )

--- a/src/main/kotlin/com/wafflestudio/spring2025/domain/registration/dto/request/UpdateRegistrationStatusRequest.kt
+++ b/src/main/kotlin/com/wafflestudio/spring2025/domain/registration/dto/request/UpdateRegistrationStatusRequest.kt
@@ -1,9 +1,7 @@
 package com.wafflestudio.spring2025.domain.registration.dto.request
 
 import com.wafflestudio.spring2025.domain.registration.model.RegistrationStatus
-import io.swagger.v3.oas.annotations.media.Schema
 
-@Schema(description = "이벤트 신청 상태 변경 요청")
 data class UpdateRegistrationStatusRequest(
     val status: RegistrationStatus? = null,
 )

--- a/src/main/kotlin/com/wafflestudio/spring2025/domain/registration/dto/response/CreateRegistrationResponse.kt
+++ b/src/main/kotlin/com/wafflestudio/spring2025/domain/registration/dto/response/CreateRegistrationResponse.kt
@@ -1,9 +1,5 @@
 package com.wafflestudio.spring2025.domain.registration.dto.response
 
-import io.swagger.v3.oas.annotations.media.Schema
-
-@Schema(description = "이벤트 신청 응답")
 data class CreateRegistrationResponse(
-    @Schema(description = "신청 id")
     val registrationPublicId: String,
 )

--- a/src/main/kotlin/com/wafflestudio/spring2025/domain/registration/dto/response/GetEventRegistrationsResponse.kt
+++ b/src/main/kotlin/com/wafflestudio/spring2025/domain/registration/dto/response/GetEventRegistrationsResponse.kt
@@ -3,36 +3,22 @@ package com.wafflestudio.spring2025.domain.registration.dto.response
 import com.wafflestudio.spring2025.domain.registration.model.Registration
 import com.wafflestudio.spring2025.domain.registration.model.RegistrationStatus
 import com.wafflestudio.spring2025.domain.user.model.User
-import io.swagger.v3.oas.annotations.media.Schema
 import java.time.Instant
 
-@Schema(description = "이벤트 신청 목록 조회 응답")
 data class GetEventRegistrationsResponse(
-    @Schema(description = "신청자 목록")
     val participants: List<EventRegistrationItem>,
-    @Schema(description = "필터에 따라 변하는 참여자 수")
     val totalCount: Int?,
-    @Schema(description = "다음 페이지 시작 offset (없으면 null)")
     val nextCursor: Int?,
-    @Schema(description = "다음 페이지 존재 여부")
     val hasNext: Boolean,
 )
 
-@Schema(description = "신청자 정보")
 data class EventRegistrationItem(
-    @Schema(description = "신청 공개 ID")
     val registrationId: String,
-    @Schema(description = "이름")
     val name: String,
-    @Schema(description = "이메일 (관리자 요청 시 노출)")
     val email: String?,
-    @Schema(description = "프로필 이미지 URL")
     val profileImage: String?,
-    @Schema(description = "신청 일시")
     val createdAt: Instant,
-    @Schema(description = "신청 상태")
     val status: RegistrationStatus,
-    @Schema(description = "대기 순번 (status가 WAITLISTED일 때만 아니면 null)")
     val waitingNum: Int?,
 ) {
     constructor(

--- a/src/main/kotlin/com/wafflestudio/spring2025/domain/registration/dto/response/GetMyRegistrationsResponse.kt
+++ b/src/main/kotlin/com/wafflestudio/spring2025/domain/registration/dto/response/GetMyRegistrationsResponse.kt
@@ -3,36 +3,22 @@ package com.wafflestudio.spring2025.domain.registration.dto.response
 import com.wafflestudio.spring2025.domain.event.model.Event
 import com.wafflestudio.spring2025.domain.registration.model.Registration
 import com.wafflestudio.spring2025.domain.registration.model.RegistrationStatus
-import io.swagger.v3.oas.annotations.media.Schema
 import java.time.Instant
 
-@Schema(description = "내 이벤트 신청 목록 응답")
 data class GetMyRegistrationsResponse(
-    @Schema(description = "신청 목록")
     val registrations: List<MyRegistrationItem>,
 )
 
-@Schema(description = "내 이벤트 신청 요약")
 data class MyRegistrationItem(
-    @Schema(description = "이벤트 공개 ID")
     val publicId: String,
-    @Schema(description = "이벤트 제목")
     val title: String,
-    @Schema(description = "이벤트 시작 시간 (ISO-8601)")
     val startsAt: Instant?,
-    @Schema(description = "이벤트 종료 시간 (ISO-8601)")
     val endsAt: Instant?,
-    @Schema(description = "신청 시작 시간 (ISO-8601)")
     val registrationStartsAt: Instant?,
-    @Schema(description = "신청 마감 시간 (ISO-8601)")
     val registrationEndsAt: Instant?,
-    @Schema(description = "정원")
     val capacity: Int?,
-    @Schema(description = "현재 신청 수 + 대기 수")
     val registrationCnt: Int,
-    @Schema(description = "신청 상태")
     val status: MyRegistrationStatus,
-    @Schema(description = "대기 순번 (WAITLISTED가 아니면 null)")
     val waitlistedNum: Int?,
 ) {
     constructor(

--- a/src/main/kotlin/com/wafflestudio/spring2025/domain/registration/dto/response/GetMyRegistrationsResponse.kt
+++ b/src/main/kotlin/com/wafflestudio/spring2025/domain/registration/dto/response/GetMyRegistrationsResponse.kt
@@ -17,11 +17,8 @@ data class MyRegistrationItem(
     val registrationStartsAt: Instant?,
     val registrationEndsAt: Instant?,
     val capacity: Int?,
-    @Schema(description = "확정 참여자 수")
     val confirmedCount: Int,
-    @Schema(description = "대기자 수")
     val waitlistCount: Int,
-    @Schema(description = "신청 상태")
     val status: MyRegistrationStatus,
     val waitlistedNum: Int?,
 ) {

--- a/src/main/kotlin/com/wafflestudio/spring2025/domain/registration/dto/response/GetRegistrationResponse.kt
+++ b/src/main/kotlin/com/wafflestudio/spring2025/domain/registration/dto/response/GetRegistrationResponse.kt
@@ -1,9 +1,7 @@
 package com.wafflestudio.spring2025.domain.registration.dto.response
 
 import com.wafflestudio.spring2025.domain.registration.model.RegistrationStatus
-import io.swagger.v3.oas.annotations.media.Schema
 
-@Schema(description = "이벤트 신청 정보 요청 응답")
 data class GetRegistrationResponse(
     val status: RegistrationStatus,
     val guestName: String,

--- a/src/main/kotlin/com/wafflestudio/spring2025/domain/registration/dto/response/PatchRegistrationResponse.kt
+++ b/src/main/kotlin/com/wafflestudio/spring2025/domain/registration/dto/response/PatchRegistrationResponse.kt
@@ -1,8 +1,5 @@
 package com.wafflestudio.spring2025.domain.registration.dto.response
 
-import io.swagger.v3.oas.annotations.media.Schema
-
-@Schema(description = "이벤트 신청 상태 변경")
 data class PatchRegistrationResponse(
     val patchEmail: String? = null,
 )

--- a/src/main/kotlin/com/wafflestudio/spring2025/domain/registration/dto/response/RegistrationGuestsResponse.kt
+++ b/src/main/kotlin/com/wafflestudio/spring2025/domain/registration/dto/response/RegistrationGuestsResponse.kt
@@ -1,29 +1,19 @@
 package com.wafflestudio.spring2025.domain.registration.dto.response
 
 import com.fasterxml.jackson.annotation.JsonProperty
-import io.swagger.v3.oas.annotations.media.Schema
 
-@Schema(description = "이벤트 참여자 명단 응답")
 data class RegistrationGuestsResponse(
-    @Schema(description = "확정 참여자 목록")
     val guests: List<Guest>,
     @JsonProperty("confirmed_count")
-    @Schema(description = "확정 참여자 수")
     val confirmedCount: Int,
     @JsonProperty("waiting_count")
-    @Schema(description = "대기 참여자 수")
     val waitingCount: Int,
 ) {
-    @Schema(description = "참여자 정보")
     data class Guest(
-        @Schema(description = "신청 공개 ID")
         val registrationPublicId: String,
-        @Schema(description = "이름")
         val name: String,
-        @Schema(description = "이메일 (관리자 요청 시 노출)")
         val email: String?,
         @JsonProperty("profile_image")
-        @Schema(description = "프로필 이미지 URL")
         val profileImage: String?,
     )
 }

--- a/src/main/kotlin/com/wafflestudio/spring2025/domain/user/controller/UserController.kt
+++ b/src/main/kotlin/com/wafflestudio/spring2025/domain/user/controller/UserController.kt
@@ -7,11 +7,6 @@ import com.wafflestudio.spring2025.domain.user.dto.PatchMeRequest
 import com.wafflestudio.spring2025.domain.user.dto.PatchMeResponse
 import com.wafflestudio.spring2025.domain.user.model.User
 import com.wafflestudio.spring2025.domain.user.service.UserService
-import io.swagger.v3.oas.annotations.Operation
-import io.swagger.v3.oas.annotations.Parameter
-import io.swagger.v3.oas.annotations.responses.ApiResponse
-import io.swagger.v3.oas.annotations.responses.ApiResponses
-import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PatchMapping
@@ -22,27 +17,19 @@ import org.springframework.web.bind.annotation.RestController
 @AuthRequired
 @RestController
 @RequestMapping("/api/users")
-@Tag(name = "User", description = "사용자 API")
 class UserController(
     private val userService: UserService,
 ) {
-    @Operation(summary = "본인 정보 조회", description = "로그인한 사용자의 정보를 조회합니다")
-    @ApiResponses(
-        value = [
-            ApiResponse(responseCode = "200", description = "사용자 정보 조회 성공"),
-            ApiResponse(responseCode = "401", description = "인증 실패 (유효하지 않은 토큰)"),
-        ],
-    )
     @AuthRequired
     @GetMapping("/me")
     fun me(
-        @Parameter(hidden = true) @LoggedInUser user: User,
+        @LoggedInUser user: User,
     ): ResponseEntity<GetMeResponse> = ResponseEntity.ok(userService.me(user))
 
     @AuthRequired
     @PatchMapping("/me")
     fun patchMe(
-        @Parameter(hidden = true) @LoggedInUser user: User,
+        @LoggedInUser user: User,
         @RequestBody request: PatchMeRequest,
     ): ResponseEntity<PatchMeResponse> {
         userService.patchMe(
@@ -54,41 +41,4 @@ class UserController(
         )
         return ResponseEntity.ok(userService.me(user))
     }
-
-//    @Operation(summary = "프로필 이미지 업로드", description = "로그인한 사용자의 프로필 이미지를 업로드(교체)합니다")
-//    @ApiResponses(
-//        value = [
-//            ApiResponse(responseCode = "204", description = "프로필 이미지 업로드 성공"),
-//            ApiResponse(responseCode = "400", description = "잘못된 요청 (파일 누락/형식 오류 등)"),
-//            ApiResponse(responseCode = "401", description = "인증 실패 (유효하지 않은 토큰)"),
-//        ],
-//    )
-//    @AuthRequired
-//    @PutMapping(
-//        "/me/profile-image",
-//        consumes = [MediaType.MULTIPART_FORM_DATA_VALUE],
-//    )
-//    fun uploadProfileImage(
-//        @Parameter(hidden = true) @LoggedInUser user: User?,
-//        @RequestPart("image") image: MultipartFile,
-//    ): ResponseEntity<Void> {
-//        userService.updateProfileImage(user, image)
-//        return ResponseEntity.noContent().build()
-//    }
-//
-//    @Operation(summary = "프로필 이미지 삭제", description = "로그인한 사용자의 프로필 이미지를 삭제(기본 이미지로 복귀)합니다")
-//    @ApiResponses(
-//        value = [
-//            ApiResponse(responseCode = "204", description = "프로필 이미지 삭제 성공"),
-//            ApiResponse(responseCode = "401", description = "인증 실패 (유효하지 않은 토큰)"),
-//        ],
-//    )
-//    @AuthRequired
-//    @DeleteMapping("/me/profile-image")
-//    fun deleteProfileImage(
-//        @Parameter(hidden = true) @LoggedInUser user: User?,
-//    ): ResponseEntity<Void> {
-//        userService.deleteProfileImage(user)
-//        return ResponseEntity.noContent().build()
-//    }
 }

--- a/src/main/kotlin/com/wafflestudio/spring2025/domain/user/identity/dto/core/UserIdentityDto.kt
+++ b/src/main/kotlin/com/wafflestudio/spring2025/domain/user/identity/dto/core/UserIdentityDto.kt
@@ -1,19 +1,12 @@
 package com.wafflestudio.spring2025.domain.user.identity.dto.core
 
 import com.wafflestudio.spring2025.domain.user.identity.model.UserIdentity
-import io.swagger.v3.oas.annotations.media.Schema
 
-@Schema(description = "소셜 계정 정보")
 data class UserIdentityDto(
-    @Schema(description = "소셜 계정 ID")
     val id: Long,
-    @Schema(description = "사용자 ID")
     val userId: Long,
-    @Schema(description = "소셜 로그인 제공자")
     val provider: String,
-    @Schema(description = "제공자 사용자 ID")
     val providerUserId: String,
-    @Schema(description = "생성 일시 (epoch milliseconds)")
     val createdAt: Long,
 ) {
     constructor(identity: UserIdentity) : this(

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -95,6 +95,13 @@ aws:
 server:
   forward-headers-strategy: framework
 
+springdoc:
+  api-docs:
+    enabled: false
+  swagger-ui:
+    url: /docs/openapi.yaml
+    disable-swagger-default-url: true
+
 ---
 spring:
   config:

--- a/src/main/resources/static/docs/openapi.yaml
+++ b/src/main/resources/static/docs/openapi.yaml
@@ -909,7 +909,7 @@ components:
           format: int32
         waitlistCount:
           type: integer
-          description: 참여 확정자 수
+          description: 대기자 수
           format: int32
         status:
           type: string

--- a/src/main/resources/static/docs/openapi.yaml
+++ b/src/main/resources/static/docs/openapi.yaml
@@ -572,6 +572,7 @@ components:
       required:
       - registrationEndsAt
       - title
+      - capacity
       - waitlistEnabled
       type: object
       properties:
@@ -849,7 +850,8 @@ components:
     MyRegistrationItem:
       required:
       - publicId
-      - registrationCnt
+      - confirmedCount
+      - waitlistCount
       - status
       - title
       type: object
@@ -885,9 +887,13 @@ components:
           description: 정원
           format: int32
           nullable: true
-        registrationCnt:
+        confirmedCount:
           type: integer
-          description: 현재 신청 수 + 대기 수
+          description: 참여 확정자 수
+          format: int32
+        waitlistCount:
+          type: integer
+          description: 참여 확정자 수
           format: int32
         status:
           type: string

--- a/src/main/resources/static/docs/openapi.yaml
+++ b/src/main/resources/static/docs/openapi.yaml
@@ -20,6 +20,7 @@ tags:
 paths:
   /api/events/{publicId}:
     get:
+      security: []
       tags:
       - Event
       summary: 이벤트 상세 조회
@@ -85,6 +86,8 @@ paths:
           description: 인증 필요
   /api/images:
     post:
+      security:
+      - bearerAuth: []
       tags:
       - Image
       summary: 이미지 업로드
@@ -151,6 +154,8 @@ paths:
           description: 인증 필요
   /api/events/{eventId}/registrations:
     get:
+      security:
+      - bearerAuth: []
       tags:
       - Registration
       summary: 이벤트 신청 목록 조회
@@ -187,6 +192,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/GetEventRegistrationsResponse"
     post:
+      security: []
       tags:
       - Registration
       summary: 이벤트 참여 신청
@@ -237,6 +243,7 @@ paths:
                 $ref: "#/components/schemas/ErrorResponse"
   /api/auth/social:
     post:
+      security: []
       tags:
       - Auth
       summary: 소셜 로그인
@@ -268,6 +275,7 @@ paths:
                 $ref: "#/components/schemas/ErrorResponse"
   /api/auth/signup:
     post:
+      security: []
       tags:
       - Auth
       summary: 이메일 회원가입
@@ -289,6 +297,8 @@ paths:
           description: 이메일 서비스 장애
   /api/auth/logout:
     post:
+      security:
+      - bearerAuth: []
       tags:
       - Auth
       summary: 로그아웃
@@ -298,6 +308,7 @@ paths:
           description: 로그아웃 성공
   /api/auth/login:
     post:
+      security: []
       tags:
       - Auth
       summary: 로그인
@@ -323,6 +334,7 @@ paths:
                 $ref: "#/components/schemas/LoginResponse"
   /api/auth/email-verification/{verificationCode}:
     post:
+      security: []
       tags:
       - Auth
       summary: 이메일 인증
@@ -383,6 +395,7 @@ paths:
           description: 인증 필요
   /api/registrations/{registrationId}:
     get:
+      security: []
       tags:
       - Registration
       summary: 신청 단건 정보 요청
@@ -401,6 +414,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/GetRegistrationResponse"
     delete:
+      security: []
       tags:
       - Registration
       summary: 신청 단건 취소
@@ -425,6 +439,8 @@ paths:
               schema:
                 $ref: "#/components/schemas/DeleteRegistrationResponse"
     patch:
+      security:
+      - bearerAuth: []
       tags:
       - Registration
       summary: 신청 단건 상태 변경
@@ -1249,6 +1265,5 @@ components:
     bearerAuth:
       type: http
       description: JWT 토큰을 입력하세요
-      name: bearerAuth
       scheme: bearer
       bearerFormat: JWT

--- a/src/main/resources/static/docs/openapi.yaml
+++ b/src/main/resources/static/docs/openapi.yaml
@@ -108,12 +108,6 @@ paths:
                   type: string
                   format: binary
       responses:
-        "401":
-          description: 인증 실패 (유효하지 않은 토큰)
-          content:
-            '*/*':
-              schema:
-                $ref: "#/components/schemas/ImageUploadResponse"
         "200":
           description: 이미지 업로드 성공
           content:
@@ -125,7 +119,13 @@ paths:
           content:
             '*/*':
               schema:
-                $ref: "#/components/schemas/ImageUploadResponse"
+                $ref: "#/components/schemas/ErrorResponse"
+        "401":
+          description: 인증 실패 (유효하지 않은 토큰)
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
   /api/events:
     post:
       tags:
@@ -212,31 +212,29 @@ paths:
               schema:
                 $ref: "#/components/schemas/CreateRegistrationResponse"
         "409":
-          description: "신청 불가: 3001(Registration already exists), 3005(Host cannot\
-            \ register), 2301(Event is full)"
+          description: "신청 불가: REGISTRATION_ALREADY_EXISTS, REGISTRATION_BLOCKED_HOST, EVENT_FULL"
           content:
             '*/*':
               schema:
-                $ref: "#/components/schemas/CreateRegistrationResponse"
+                $ref: "#/components/schemas/ErrorResponse"
         "400":
-          description: "유효하지 않은 요청: 3003(Wrong guest name), 3004(Wrong guest email),\
-            \ 2204(Invalid registration window)"
+          description: "유효하지 않은 요청: REGISTRATION_WRONG_NAME, REGISTRATION_WRONG_EMAIL, NOT_WITHIN_REGISTRATION_WINDOW"
           content:
             '*/*':
               schema:
-                $ref: "#/components/schemas/CreateRegistrationResponse"
+                $ref: "#/components/schemas/ErrorResponse"
         "403":
-          description: "권한 없음: 3006(Banned user cannot register)"
+          description: "권한 없음: REGISTRATION_BLOCKED_BANNED"
           content:
             '*/*':
               schema:
-                $ref: "#/components/schemas/CreateRegistrationResponse"
+                $ref: "#/components/schemas/ErrorResponse"
         "404":
-          description: "이벤트 없음: 2001(Event not found)"
+          description: "이벤트 없음: EVENT_NOT_FOUND"
           content:
             '*/*':
               schema:
-                $ref: "#/components/schemas/CreateRegistrationResponse"
+                $ref: "#/components/schemas/ErrorResponse"
   /api/auth/social:
     post:
       tags:
@@ -261,13 +259,13 @@ paths:
           content:
             '*/*':
               schema:
-                $ref: "#/components/schemas/LoginResponse"
+                $ref: "#/components/schemas/ErrorResponse"
         "401":
           description: 인증 실패
           content:
             '*/*':
               schema:
-                $ref: "#/components/schemas/LoginResponse"
+                $ref: "#/components/schemas/ErrorResponse"
   /api/auth/signup:
     post:
       tags:
@@ -316,7 +314,7 @@ paths:
           content:
             '*/*':
               schema:
-                $ref: "#/components/schemas/LoginResponse"
+                $ref: "#/components/schemas/ErrorResponse"
         "200":
           description: "로그인 성공, JWT 토큰 반환"
           content:
@@ -354,7 +352,7 @@ paths:
           content:
             '*/*':
               schema:
-                $ref: "#/components/schemas/UserDto"
+                $ref: "#/components/schemas/ErrorResponse"
         "200":
           description: 사용자 정보 조회 성공
           content:
@@ -522,43 +520,52 @@ components:
         title:
           type: string
           description: 이벤트 제목
+          nullable: true
           example: 정기 모임
         description:
           type: string
           description: 이벤트 설명
+          nullable: true
           example: 정기 모임입니다
         location:
           type: string
           description: 장소
+          nullable: true
           example: 강의실 101
         startsAt:
           type: string
           description: 시작 시간 (ISO-8601)
           format: date-time
+          nullable: true
           example: 2026-02-02T18:00:00Z
         endsAt:
           type: string
           description: 종료 시간 (ISO-8601)
           format: date-time
+          nullable: true
           example: 2026-02-02T20:00:00Z
         capacity:
           type: integer
           description: 정원
           format: int32
+          nullable: true
           example: 30
         waitlistEnabled:
           type: boolean
           description: 대기 명단 사용 여부
+          nullable: true
           example: true
         registrationStartsAt:
           type: string
           description: 신청 시작 시간 (ISO-8601)
           format: date-time
+          nullable: true
           example: 2026-02-02T17:00:00Z
         registrationEndsAt:
           type: string
           description: 신청 마감 시간 (ISO-8601)
           format: date-time
+          nullable: true
           example: 2026-02-02T17:30:00Z
       description: 일정 수정 요청
     UpdateEventResponse:
@@ -572,22 +579,28 @@ components:
           type: string
         description:
           type: string
+          nullable: true
         location:
           type: string
+          nullable: true
         startsAt:
           type: string
           format: date-time
+          nullable: true
         endsAt:
           type: string
           format: date-time
+          nullable: true
         capacity:
           type: integer
           format: int32
+          nullable: true
         waitlistEnabled:
           type: boolean
         registrationStartsAt:
           type: string
           format: date-time
+          nullable: true
         registrationEndsAt:
           type: string
           format: date-time
@@ -616,20 +629,24 @@ components:
         description:
           type: string
           description: 이벤트 설명
+          nullable: true
           example: 정기 모임입니다
         location:
           type: string
           description: 장소
+          nullable: true
           example: 강의실 101
         startsAt:
           type: string
           description: 시작 시간 (ISO-8601)
           format: date-time
+          nullable: true
           example: 2026-02-02T18:00:00Z
         endsAt:
           type: string
           description: 종료 시간 (ISO-8601)
           format: date-time
+          nullable: true
           example: 2026-02-02T20:00:00Z
         capacity:
           type: integer
@@ -644,6 +661,7 @@ components:
           type: string
           description: 신청 시작 시간 (ISO-8601). null인 경우 요청 시점으로 자동 설정됩니다.
           format: date-time
+          nullable: true
           example: 2026-02-02T17:00:00Z
         registrationEndsAt:
           type: string
@@ -664,9 +682,11 @@ components:
         guestName:
           type: string
           description: 비회원 이름
+          nullable: true
         guestEmail:
           type: string
           description: 비회원 이메일
+          nullable: true
       description: 이벤트 신청 요청
     CreateRegistrationResponse:
       required:
@@ -720,6 +740,7 @@ components:
         profileImage:
           type: string
           description: 프로필 이미지 URL
+          nullable: true
           example: https://cdn.example.com/profile.png
       description: 회원가입 요청
     LoginRequest:
@@ -742,12 +763,16 @@ components:
       properties:
         name:
           type: string
+          nullable: true
         email:
           type: string
+          nullable: true
         password:
           type: string
+          nullable: true
         profileImage:
           type: string
+          nullable: true
     UserDto:
       required:
       - email
@@ -764,11 +789,13 @@ components:
           type: string
         profileImage:
           type: string
+          nullable: true
     UpdateRegistrationStatusRequest:
       type: object
       properties:
         status:
           type: string
+          nullable: true
           enum:
           - HOST
           - CONFIRMED
@@ -780,6 +807,7 @@ components:
       properties:
         patchEmail:
           type: string
+          nullable: true
       description: 이벤트 신청 상태 변경
     GetRegistrationResponse:
       required:
@@ -836,22 +864,27 @@ components:
           type: string
           description: 이벤트 시작 시간 (ISO-8601)
           format: date-time
+          nullable: true
         endsAt:
           type: string
           description: 이벤트 종료 시간 (ISO-8601)
           format: date-time
+          nullable: true
         registrationStartsAt:
           type: string
           description: 신청 시작 시간 (ISO-8601)
           format: date-time
+          nullable: true
         registrationEndsAt:
           type: string
           description: 신청 마감 시간 (ISO-8601)
           format: date-time
+          nullable: true
         capacity:
           type: integer
           description: 정원
           format: int32
+          nullable: true
         registrationCnt:
           type: integer
           description: 현재 신청 수 + 대기 수
@@ -867,6 +900,7 @@ components:
           type: integer
           description: 대기 순번 (WAITLISTED가 아니면 null)
           format: int32
+          nullable: true
       description: 내 이벤트 신청 요약
     CapabilitiesInfo:
       required:
@@ -941,7 +975,8 @@ components:
       - publicId
       - registrationEndsAt
       - title
-      - totalApplicants
+      - confirmedCount
+      - waitlistCount
       type: object
       properties:
         publicId:
@@ -980,9 +1015,14 @@ components:
           format: int32
           nullable: true
           example: 10
-        totalApplicants:
+        confirmedCount:
           type: integer
-          description: 총 신청자 수(확정+대기 등)
+          description: 참여 확정 신청자 수
+          format: int32
+          example: 8
+        waitlistCount:
+          type: integer
+          description: 대기자 수
           format: int32
           example: 8
         registrationStartsAt:
@@ -1072,9 +1112,11 @@ components:
         email:
           type: string
           description: 이메일 (관리자 요청 시 노출)
+          nullable: true
         profileImage:
           type: string
           description: 프로필 이미지 URL
+          nullable: true
         createdAt:
           type: string
           description: 신청 일시
@@ -1091,6 +1133,7 @@ components:
           type: integer
           description: 대기 순번 (status가 WAITLISTED일 때만 아니면 null)
           format: int32
+          nullable: true
       description: 신청자 정보
     GetEventRegistrationsResponse:
       required:
@@ -1107,10 +1150,12 @@ components:
           type: integer
           description: 필터에 따라 변하는 참여자 수
           format: int32
+          nullable: true
         nextCursor:
           type: integer
           description: 다음 페이지 시작 offset (없으면 null)
           format: int32
+          nullable: true
         hasNext:
           type: boolean
           description: 다음 페이지 존재 여부
@@ -1120,7 +1165,8 @@ components:
       - publicId
       - registrationEndsAt
       - title
-      - totalApplicants
+      - confirmedCount
+      - waitlistCount
       type: object
       properties:
         publicId:
@@ -1130,19 +1176,26 @@ components:
         startsAt:
           type: string
           format: date-time
+          nullable: true
         endsAt:
           type: string
           format: date-time
+          nullable: true
         registrationStartsAt:
           type: string
           format: date-time
+          nullable: true
         registrationEndsAt:
           type: string
           format: date-time
         capacity:
           type: integer
           format: int32
-        totalApplicants:
+          nullable: true
+        confirmedCount:
+          type: integer
+          format: int32
+        waitlistCount:
           type: integer
           format: int32
     MyEventsInfiniteResponse:
@@ -1158,6 +1211,7 @@ components:
         nextCursor:
           type: string
           format: date-time
+          nullable: true
         hasNext:
           type: boolean
     DeleteRegistrationRequest:
@@ -1166,12 +1220,31 @@ components:
         guestName:
           type: string
           description: 비회원 이름
+          nullable: true
         guestEmail:
           type: string
           description: 비회원 이메일
+          nullable: true
       description: 이벤트 취소 요청
     DeleteRegistrationResponse:
       type: object
+    ErrorResponse:
+      required:
+      - code
+      - message
+      - title
+      type: object
+      properties:
+        code:
+          type: string
+          description: 에러 코드
+        title:
+          type: string
+          description: 에러 제목
+        message:
+          type: string
+          description: 에러 메시지
+      description: 에러 응답
   securitySchemes:
     bearerAuth:
       type: http

--- a/src/main/resources/static/docs/openapi.yaml
+++ b/src/main/resources/static/docs/openapi.yaml
@@ -1,0 +1,1181 @@
+openapi: 3.0.1
+info:
+  title: Moiming - Event Schedule Management System API
+  description: 모임 일정 관리 시스템 '모이밍' API 문서
+  version: "1.0"
+servers:
+- url: http://localhost:8080
+  description: Generated server url
+tags:
+- name: Event
+  description: 이벤트 관리 API
+- name: Registration
+  description: 신청 API
+- name: Auth
+  description: 인증 API
+- name: User
+  description: 사용자 API
+- name: Image
+  description: 이미지 API
+paths:
+  /api/events/{publicId}:
+    get:
+      tags:
+      - Event
+      summary: 이벤트 상세 조회
+      description: 이벤트 상세 정보를 조회합니다
+      parameters:
+      - name: publicId
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          description: OK
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/EventDetailResponse"
+    put:
+      tags:
+      - Event
+      summary: 이벤트 수정
+      description: 이벤트를 수정합니다
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: publicId
+        in: path
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UpdateEventRequest"
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/UpdateEventResponse"
+        "401":
+          description: 인증 필요
+    delete:
+      tags:
+      - Event
+      summary: 이벤트 삭제
+      description: 이벤트를 삭제합니다
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: publicId
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        "204":
+          description: No Content
+        "401":
+          description: 인증 필요
+  /api/images:
+    post:
+      tags:
+      - Image
+      summary: 이미지 업로드
+      description: 서버 저장소에 이미지를 업로드합니다.
+      parameters:
+      - name: prefix
+        in: query
+        description: 이미지를 저장할 상위 경로
+        required: false
+        schema:
+          type: string
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              required:
+              - image
+              type: object
+              properties:
+                image:
+                  type: string
+                  format: binary
+      responses:
+        "401":
+          description: 인증 실패 (유효하지 않은 토큰)
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ImageUploadResponse"
+        "200":
+          description: 이미지 업로드 성공
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ImageUploadResponse"
+        "400":
+          description: 잘못된 요청 (파일 누락/형식 오류 등)
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ImageUploadResponse"
+  /api/events:
+    post:
+      tags:
+      - Event
+      summary: 이벤트 생성
+      description: 새로운 이벤트를 생성합니다
+      security:
+      - bearerAuth: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateEventRequest"
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/CreateEventResponse"
+        "401":
+          description: 인증 필요
+  /api/events/{eventId}/registrations:
+    get:
+      tags:
+      - Registration
+      summary: 이벤트 신청 목록 조회
+      description: 특정 이벤트에 속한 신청 목록을 조회합니다. 신청 상태(CONFIRMED/WAITLISTED/BANNED)와 신청
+        시각을 포함해 반환합니다.
+      parameters:
+      - name: eventId
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: status
+        in: query
+        required: false
+        schema:
+          type: string
+      - name: orderBy
+        in: query
+        required: false
+        schema:
+          type: string
+      - name: cursor
+        in: query
+        description: 다음 페이지 시작 offset (없으면 0부터)
+        required: false
+        schema:
+          type: integer
+          format: int32
+      responses:
+        "200":
+          description: OK
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/GetEventRegistrationsResponse"
+    post:
+      tags:
+      - Registration
+      summary: 이벤트 참여 신청
+      description: "특정 이벤트에 신청합니다. 정원이 남아있으면 CONFIRMED로 등록되고, 정원이 찼으나 대기 명단이 허용된 경\
+        우 WAITLISTED로 등록됩니다. 정원이 찼고 대기 명단이 비활성화된 경우 신청이 거절됩니다."
+      parameters:
+      - name: eventId
+        in: path
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateRegistrationRequest"
+        required: true
+      responses:
+        "200":
+          description: 신청 성공
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/CreateRegistrationResponse"
+        "409":
+          description: "신청 불가: 3001(Registration already exists), 3005(Host cannot\
+            \ register), 2301(Event is full)"
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/CreateRegistrationResponse"
+        "400":
+          description: "유효하지 않은 요청: 3003(Wrong guest name), 3004(Wrong guest email),\
+            \ 2204(Invalid registration window)"
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/CreateRegistrationResponse"
+        "403":
+          description: "권한 없음: 3006(Banned user cannot register)"
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/CreateRegistrationResponse"
+        "404":
+          description: "이벤트 없음: 2001(Event not found)"
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/CreateRegistrationResponse"
+  /api/auth/social:
+    post:
+      tags:
+      - Auth
+      summary: 소셜 로그인
+      description: 소셜 로그인을 요청합니다.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SocialLoginRequest"
+        required: true
+      responses:
+        "200":
+          description: 소셜 로그인 성공
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/LoginResponse"
+        "409":
+          description: 이미 가입된 이메일
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/LoginResponse"
+        "401":
+          description: 인증 실패
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/LoginResponse"
+  /api/auth/signup:
+    post:
+      tags:
+      - Auth
+      summary: 이메일 회원가입
+      description: 새로운 사용자를 등록하고 인증 이메일을 발송합니다. 이메일 인증 후 가입이 완료됩니다.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SignupRequest"
+        required: true
+      responses:
+        "409":
+          description: 이미 존재하는 email
+        "204":
+          description: 인증 이메일 발송 성공
+        "400":
+          description: 잘못된 요청 (유효하지 않은 email/password/name)
+        "503":
+          description: 이메일 서비스 장애
+  /api/auth/logout:
+    post:
+      tags:
+      - Auth
+      summary: 로그아웃
+      description: 현재 JWT 토큰을 블랙리스트에 추가하여 로그아웃합니다
+      responses:
+        "204":
+          description: 로그아웃 성공
+  /api/auth/login:
+    post:
+      tags:
+      - Auth
+      summary: 로그인
+      description: email로 로그인하여 JWT 토큰을 발급받습니다
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/LoginRequest"
+        required: true
+      responses:
+        "401":
+          description: 인증 실패
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/LoginResponse"
+        "200":
+          description: "로그인 성공, JWT 토큰 반환"
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/LoginResponse"
+  /api/auth/email-verification/{verificationCode}:
+    post:
+      tags:
+      - Auth
+      summary: 이메일 인증
+      description: 이메일로 받은 인증 코드를 검증하고 회원가입을 완료합니다
+      parameters:
+      - name: verificationCode
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        "400":
+          description: 유효하지 않거나 만료된 인증 코드
+        "200":
+          description: "인증 성공, 유저 등록 완료"
+  /api/users/me:
+    get:
+      tags:
+      - User
+      summary: 본인 정보 조회
+      description: 로그인한 사용자의 정보를 조회합니다
+      security:
+      - bearerAuth: []
+      responses:
+        "401":
+          description: 인증 실패 (유효하지 않은 토큰)
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/UserDto"
+        "200":
+          description: 사용자 정보 조회 성공
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/UserDto"
+    patch:
+      tags:
+      - User
+      summary: 본인 정보 수정
+      description: 로그인한 사용자의 정보를 수정합니다
+      security:
+      - bearerAuth: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PatchMeRequest"
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/UserDto"
+        "401":
+          description: 인증 필요
+  /api/registrations/{registrationId}:
+    get:
+      tags:
+      - Registration
+      summary: 신청 단건 정보 요청
+      description: 신청 단건의 정보를 반환합니다.
+      parameters:
+      - name: registrationId
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          description: OK
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/GetRegistrationResponse"
+    delete:
+      tags:
+      - Registration
+      summary: 신청 단건 취소
+      description: 신청 단건 리소스를 취소합니다.
+      parameters:
+      - name: registrationId
+        in: path
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/DeleteRegistrationRequest"
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/DeleteRegistrationResponse"
+    patch:
+      tags:
+      - Registration
+      summary: 신청 단건 상태 변경
+      description: 신청 단건 리소스의 상태를 변경합니다. 사용자가 본인의 신청을 취소하는 경우와 관리자가 강제 취소/밴 처리하는 경우를
+        로직 레벨에서 구분합니다.
+      parameters:
+      - name: registrationId
+        in: path
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UpdateRegistrationStatusRequest"
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/PatchRegistrationResponse"
+  /api/registrations/me:
+    get:
+      tags:
+      - Registration
+      summary: 내 이벤트 신청 목록 조회
+      description: 로그인한 사용자의 이벤트 신청 목록을 조회합니다. 최신 신청 순으로 반환되며 page/size로 페이징합니다.
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: page
+        in: query
+        required: false
+        schema:
+          type: integer
+          format: int32
+          default: 0
+      - name: size
+        in: query
+        required: false
+        schema:
+          type: integer
+          format: int32
+          default: 20
+      responses:
+        "200":
+          description: OK
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/GetMyRegistrationsResponse"
+        "401":
+          description: 인증 필요
+  /api/events/me:
+    get:
+      tags:
+      - Event
+      summary: 내가 만든 이벤트 목록 조회 (무한 스크롤)
+      description: 로그인된 사용자가 생성한 이벤트 목록을 무한 스크롤 방식(cursor)으로 조회합니다
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: cursor
+        in: query
+        required: false
+        schema:
+          type: string
+          format: date-time
+      - name: size
+        in: query
+        required: false
+        schema:
+          type: integer
+          format: int32
+          default: 5
+      responses:
+        "200":
+          description: OK
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/MyEventsInfiniteResponse"
+        "401":
+          description: 인증 필요
+components:
+  schemas:
+    UpdateEventRequest:
+      type: object
+      properties:
+        title:
+          type: string
+          description: 이벤트 제목
+          example: 정기 모임
+        description:
+          type: string
+          description: 이벤트 설명
+          example: 정기 모임입니다
+        location:
+          type: string
+          description: 장소
+          example: 강의실 101
+        startsAt:
+          type: string
+          description: 시작 시간 (ISO-8601)
+          format: date-time
+          example: 2026-02-02T18:00:00Z
+        endsAt:
+          type: string
+          description: 종료 시간 (ISO-8601)
+          format: date-time
+          example: 2026-02-02T20:00:00Z
+        capacity:
+          type: integer
+          description: 정원
+          format: int32
+          example: 30
+        waitlistEnabled:
+          type: boolean
+          description: 대기 명단 사용 여부
+          example: true
+        registrationStartsAt:
+          type: string
+          description: 신청 시작 시간 (ISO-8601)
+          format: date-time
+          example: 2026-02-02T17:00:00Z
+        registrationEndsAt:
+          type: string
+          description: 신청 마감 시간 (ISO-8601)
+          format: date-time
+          example: 2026-02-02T17:30:00Z
+      description: 일정 수정 요청
+    UpdateEventResponse:
+      required:
+      - registrationEndsAt
+      - title
+      - waitlistEnabled
+      type: object
+      properties:
+        title:
+          type: string
+        description:
+          type: string
+        location:
+          type: string
+        startsAt:
+          type: string
+          format: date-time
+        endsAt:
+          type: string
+          format: date-time
+        capacity:
+          type: integer
+          format: int32
+        waitlistEnabled:
+          type: boolean
+        registrationStartsAt:
+          type: string
+          format: date-time
+        registrationEndsAt:
+          type: string
+          format: date-time
+    ImageUploadResponse:
+      required:
+      - key
+      - url
+      type: object
+      properties:
+        key:
+          type: string
+        url:
+          type: string
+    CreateEventRequest:
+      required:
+      - capacity
+      - registrationEndsAt
+      - title
+      - waitlistEnabled
+      type: object
+      properties:
+        title:
+          type: string
+          description: 이벤트 제목
+          example: 정기 모임
+        description:
+          type: string
+          description: 이벤트 설명
+          example: 정기 모임입니다
+        location:
+          type: string
+          description: 장소
+          example: 강의실 101
+        startsAt:
+          type: string
+          description: 시작 시간 (ISO-8601)
+          format: date-time
+          example: 2026-02-02T18:00:00Z
+        endsAt:
+          type: string
+          description: 종료 시간 (ISO-8601)
+          format: date-time
+          example: 2026-02-02T20:00:00Z
+        capacity:
+          type: integer
+          description: 정원
+          format: int32
+          example: 30
+        waitlistEnabled:
+          type: boolean
+          description: 대기 명단 사용 여부
+          example: true
+        registrationStartsAt:
+          type: string
+          description: 신청 시작 시간 (ISO-8601). null인 경우 요청 시점으로 자동 설정됩니다.
+          format: date-time
+          example: 2026-02-02T17:00:00Z
+        registrationEndsAt:
+          type: string
+          description: 신청 마감 시간 (ISO-8601)
+          format: date-time
+          example: 2026-02-02T17:30:00Z
+      description: 일정 생성 요청
+    CreateEventResponse:
+      required:
+      - publicId
+      type: object
+      properties:
+        publicId:
+          type: string
+    CreateRegistrationRequest:
+      type: object
+      properties:
+        guestName:
+          type: string
+          description: 비회원 이름
+        guestEmail:
+          type: string
+          description: 비회원 이메일
+      description: 이벤트 신청 요청
+    CreateRegistrationResponse:
+      required:
+      - registrationPublicId
+      type: object
+      properties:
+        registrationPublicId:
+          type: string
+          description: 신청 id
+      description: 이벤트 신청 응답
+    SocialLoginRequest:
+      required:
+      - code
+      - provider
+      type: object
+      properties:
+        provider:
+          type: string
+          description: 소셜로그인 제공자
+          example: GOOGLE
+        code:
+          type: string
+          description: 인가 코드 (authorization code)
+      description: 소셜 로그인 요청
+    LoginResponse:
+      required:
+      - token
+      type: object
+      properties:
+        token:
+          type: string
+    SignupRequest:
+      required:
+      - email
+      - name
+      - password
+      type: object
+      properties:
+        email:
+          type: string
+          description: 사용자 이메일
+          example: user@example.com
+        name:
+          type: string
+          description: 사용자 이름
+          example: 홍길동
+        password:
+          type: string
+          description: 비밀번호
+          example: password123
+        profileImage:
+          type: string
+          description: 프로필 이미지 URL
+          example: https://cdn.example.com/profile.png
+      description: 회원가입 요청
+    LoginRequest:
+      required:
+      - email
+      - password
+      type: object
+      properties:
+        email:
+          type: string
+          description: 사용자 이메일
+          example: user@example.com
+        password:
+          type: string
+          description: 사용자 비밀번호
+          example: mypassword
+      description: 로그인 요청
+    PatchMeRequest:
+      type: object
+      properties:
+        name:
+          type: string
+        email:
+          type: string
+        password:
+          type: string
+        profileImage:
+          type: string
+    UserDto:
+      required:
+      - email
+      - id
+      - name
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        email:
+          type: string
+        name:
+          type: string
+        profileImage:
+          type: string
+    UpdateRegistrationStatusRequest:
+      type: object
+      properties:
+        status:
+          type: string
+          enum:
+          - HOST
+          - CONFIRMED
+          - WAITLISTED
+          - BANNED
+      description: 이벤트 신청 상태 변경 요청
+    PatchRegistrationResponse:
+      type: object
+      properties:
+        patchEmail:
+          type: string
+      description: 이벤트 신청 상태 변경
+    GetRegistrationResponse:
+      required:
+      - guestName
+      - registrationPublicId
+      - reservationEmail
+      - status
+      - waitlistPosition
+      type: object
+      properties:
+        status:
+          type: string
+          enum:
+          - HOST
+          - CONFIRMED
+          - WAITLISTED
+          - BANNED
+        guestName:
+          type: string
+        waitlistPosition:
+          type: integer
+          format: int32
+        registrationPublicId:
+          type: string
+        reservationEmail:
+          type: string
+      description: 이벤트 신청 정보 요청 응답
+    GetMyRegistrationsResponse:
+      required:
+      - registrations
+      type: object
+      properties:
+        registrations:
+          type: array
+          description: 신청 목록
+          items:
+            $ref: "#/components/schemas/MyRegistrationItem"
+      description: 내 이벤트 신청 목록 응답
+    MyRegistrationItem:
+      required:
+      - publicId
+      - registrationCnt
+      - status
+      - title
+      type: object
+      properties:
+        publicId:
+          type: string
+          description: 이벤트 공개 ID
+        title:
+          type: string
+          description: 이벤트 제목
+        startsAt:
+          type: string
+          description: 이벤트 시작 시간 (ISO-8601)
+          format: date-time
+        endsAt:
+          type: string
+          description: 이벤트 종료 시간 (ISO-8601)
+          format: date-time
+        registrationStartsAt:
+          type: string
+          description: 신청 시작 시간 (ISO-8601)
+          format: date-time
+        registrationEndsAt:
+          type: string
+          description: 신청 마감 시간 (ISO-8601)
+          format: date-time
+        capacity:
+          type: integer
+          description: 정원
+          format: int32
+        registrationCnt:
+          type: integer
+          description: 현재 신청 수 + 대기 수
+          format: int32
+        status:
+          type: string
+          description: 신청 상태
+          enum:
+          - CONFIRMED
+          - WAITLISTED
+          - BANNED
+        waitlistedNum:
+          type: integer
+          description: 대기 순번 (WAITLISTED가 아니면 null)
+          format: int32
+      description: 내 이벤트 신청 요약
+    CapabilitiesInfo:
+      required:
+      - apply
+      - cancel
+      - shareLink
+      - wait
+      type: object
+      properties:
+        shareLink:
+          type: boolean
+          description: 공유 링크 가능 여부
+          example: false
+        apply:
+          type: boolean
+          description: 참여 신청 가능 여부(확정 자리 신청)
+          example: false
+        wait:
+          type: boolean
+          description: 대기 신청 가능 여부(정원 찼을 때)
+          example: false
+        cancel:
+          type: boolean
+          description: 신청 취소 가능 여부
+          example: true
+      description: 가능한 동작 블록
+    CreatorInfo:
+      required:
+      - email
+      - name
+      type: object
+      properties:
+        name:
+          type: string
+          description: 이름
+          example: 홍길동
+        email:
+          type: string
+          description: 이메일
+          example: user@example.com
+        profileImage:
+          type: string
+          description: 프로필 이미지
+          nullable: true
+          example: https://example.com/profile.png
+      description: 생성자 정보 블록
+    EventDetailResponse:
+      required:
+      - capabilities
+      - creator
+      - event
+      - guestsPreview
+      - viewer
+      type: object
+      properties:
+        event:
+          $ref: "#/components/schemas/EventInfo"
+        creator:
+          $ref: "#/components/schemas/CreatorInfo"
+        viewer:
+          $ref: "#/components/schemas/ViewerInfo"
+        capabilities:
+          $ref: "#/components/schemas/CapabilitiesInfo"
+        guestsPreview:
+          type: array
+          description: 참여자 미리보기 목록
+          items:
+            $ref: "#/components/schemas/GuestPreview"
+      description: 일정 상세 조회 응답
+    EventInfo:
+      required:
+      - publicId
+      - registrationEndsAt
+      - title
+      - totalApplicants
+      type: object
+      properties:
+        publicId:
+          type: string
+          description: 이벤트 publicId
+          example: dj8sadj10djnkas
+        title:
+          type: string
+          description: 이벤트 제목
+          example: 제2회 기획 세미나
+        description:
+          type: string
+          description: 이벤트 설명
+          nullable: true
+          example: 일정 상세 설명...
+        location:
+          type: string
+          description: 장소
+          nullable: true
+          example: 서울대
+        startsAt:
+          type: string
+          description: 시작 시간 (ISO-8601)
+          format: date-time
+          nullable: true
+          example: 2026-02-02T18:00:00Z
+        endsAt:
+          type: string
+          description: 종료 시간 (ISO-8601)
+          format: date-time
+          nullable: true
+          example: 2026-02-02T20:00:00Z
+        capacity:
+          type: integer
+          description: 정원
+          format: int32
+          nullable: true
+          example: 10
+        totalApplicants:
+          type: integer
+          description: 총 신청자 수(확정+대기 등)
+          format: int32
+          example: 8
+        registrationStartsAt:
+          type: string
+          description: 신청 시작 시간 (ISO-8601)
+          format: date-time
+          nullable: true
+          example: 2026-02-02T17:00:00Z
+        registrationEndsAt:
+          type: string
+          description: 신청 마감 시간 (ISO-8601)
+          format: date-time
+          example: 2026-02-02T17:00:00Z
+      description: 이벤트 정보 블록
+    GuestPreview:
+      required:
+      - name
+      type: object
+      properties:
+        id:
+          type: integer
+          description: 참여자 ID (비회원이면 null)
+          format: int64
+          nullable: true
+          example: 1
+        name:
+          type: string
+          description: 참여자 이름
+          example: 홍길동
+        profileImage:
+          type: string
+          description: 프로필 이미지 URL
+          nullable: true
+          example: https://example.com/profile.png
+      description: 참여자 미리보기 정보
+    ViewerInfo:
+      required:
+      - status
+      type: object
+      properties:
+        status:
+          type: string
+          description: 이벤트 조회자(Viewer)의 상태
+          example: WAITLISTED
+          enum:
+          - HOST
+          - CONFIRMED
+          - WAITLISTED
+          - BANNED
+          - NONE
+        name:
+          type: string
+          description: viewer 이름 (비회원이면 null)
+          nullable: true
+          example: 홍길동
+        waitlistPosition:
+          type: integer
+          description: "대기 순번 (WAITLISTED일 때만 숫자, 아니면 null)"
+          format: int32
+          nullable: true
+          example: 3
+        registrationPublicId:
+          type: string
+          description: "registrationPublicId (게스트면 값, 아니면 null)"
+          nullable: true
+          example: "1"
+        reservationEmail:
+          type: string
+          description: "예약 이메일(게스트면 guestEmail, 로그인 유저면 user email 등 정책에 따름)"
+          nullable: true
+          example: skdfsj@gmaldkl
+      description: 조회자(viewer) 정보 블록
+    EventRegistrationItem:
+      required:
+      - createdAt
+      - name
+      - registrationId
+      - status
+      type: object
+      properties:
+        registrationId:
+          type: string
+          description: 신청 공개 ID
+        name:
+          type: string
+          description: 이름
+        email:
+          type: string
+          description: 이메일 (관리자 요청 시 노출)
+        profileImage:
+          type: string
+          description: 프로필 이미지 URL
+        createdAt:
+          type: string
+          description: 신청 일시
+          format: date-time
+        status:
+          type: string
+          description: 신청 상태
+          enum:
+          - HOST
+          - CONFIRMED
+          - WAITLISTED
+          - BANNED
+        waitingNum:
+          type: integer
+          description: 대기 순번 (status가 WAITLISTED일 때만 아니면 null)
+          format: int32
+      description: 신청자 정보
+    GetEventRegistrationsResponse:
+      required:
+      - hasNext
+      - participants
+      type: object
+      properties:
+        participants:
+          type: array
+          description: 신청자 목록
+          items:
+            $ref: "#/components/schemas/EventRegistrationItem"
+        totalCount:
+          type: integer
+          description: 필터에 따라 변하는 참여자 수
+          format: int32
+        nextCursor:
+          type: integer
+          description: 다음 페이지 시작 offset (없으면 null)
+          format: int32
+        hasNext:
+          type: boolean
+          description: 다음 페이지 존재 여부
+      description: 이벤트 신청 목록 조회 응답
+    MyEventResponse:
+      required:
+      - publicId
+      - registrationEndsAt
+      - title
+      - totalApplicants
+      type: object
+      properties:
+        publicId:
+          type: string
+        title:
+          type: string
+        startsAt:
+          type: string
+          format: date-time
+        endsAt:
+          type: string
+          format: date-time
+        registrationStartsAt:
+          type: string
+          format: date-time
+        registrationEndsAt:
+          type: string
+          format: date-time
+        capacity:
+          type: integer
+          format: int32
+        totalApplicants:
+          type: integer
+          format: int32
+    MyEventsInfiniteResponse:
+      required:
+      - events
+      - hasNext
+      type: object
+      properties:
+        events:
+          type: array
+          items:
+            $ref: "#/components/schemas/MyEventResponse"
+        nextCursor:
+          type: string
+          format: date-time
+        hasNext:
+          type: boolean
+    DeleteRegistrationRequest:
+      type: object
+      properties:
+        guestName:
+          type: string
+          description: 비회원 이름
+        guestEmail:
+          type: string
+          description: 비회원 이메일
+      description: 이벤트 취소 요청
+    DeleteRegistrationResponse:
+      type: object
+  securitySchemes:
+    bearerAuth:
+      type: http
+      description: JWT 토큰을 입력하세요
+      name: bearerAuth
+      scheme: bearer
+      bearerFormat: JWT

--- a/src/main/resources/static/docs/swagger-ui.html
+++ b/src/main/resources/static/docs/swagger-ui.html
@@ -1,0 +1,36 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>MoiMing API Docs</title>
+    <link rel="stylesheet" href="/webjars/swagger-ui/swagger-ui.css" />
+    <style>
+      html,
+      body {
+        margin: 0;
+        height: 100%;
+      }
+      #swagger-ui {
+        height: 100%;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="swagger-ui"></div>
+    <script src="/webjars/swagger-ui/swagger-ui-bundle.js"></script>
+    <script src="/webjars/swagger-ui/swagger-ui-standalone-preset.js"></script>
+    <script>
+      window.onload = function () {
+        window.ui = SwaggerUIBundle({
+          url: "/docs/openapi.yaml",
+          dom_id: "#swagger-ui",
+          deepLinking: true,
+          presets: [SwaggerUIBundle.presets.apis, SwaggerUIStandalonePreset],
+          plugins: [SwaggerUIBundle.plugins.DownloadUrl],
+          layout: "StandaloneLayout",
+        });
+      };
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## ✨ Feature PR (to dev)

### 🧪 로컬 테스트 여부 (작업자 체크)
- [x] 로컬에서 Swagger 혹은 테스트 코드로 동작을 확인했습니다.

### 📄 documentation 최신화 여부
> 변경사항과 관련된 API의 swagger documentation이 실제 동작과 일치하는지 확인합니다.
- [x] (작업자) 확인하였습니다.
- [x] (리뷰어) 확인하였습니다.

### 📌 작업 내용(what & why)

- 기존에 어노테이션 형식으로 작성된 Swagger 문서화 방식을 resources/static.docs/openapi.yaml에 저장하는 정적 방식으로 수정하였습니다. Codex한테 물어가면서 작업했는데 제대로 한건지 확신은 없습니다..

### 🔎 영향 범위

### 📡 API 변경사항 (있다면)

### 👀 집중 리뷰 요청사항 (있다면)

- 대부분 파일 수정사항은 어노테이션 제거한 것이 전부여서 openapi.yaml, swagger-ui.html, application.yaml 이 3가지 중심으로 리뷰해주시면 감사하겠습니다.

### 🔥 관련 이슈
- closes #221 
