### PR TITLE
:seedling: 로컬 테스팅 config 추가

### DIFF
--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -1,0 +1,7 @@
+spring:
+  config:
+    activate:
+      on-profile: local
+  data:
+    redis:
+      host: localhost


### PR DESCRIPTION
## ✨ Feature PR (to dev)

### 🧪 로컬 테스트 여부 (작업자 체크)
- [x] 로컬에서 Swagger 혹은 테스트 코드로 동작을 확인했습니다.

### 📄 documentation 최신화 여부
> 변경사항과 관련된 API의 swagger documentation이 실제 동작과 일치하는지 확인합니다.
- [x] (작업자) 확인하였습니다.
- [ ] (리뷰어) 확인하였습니다.

### 📌 작업 내용(what & why)
- 로컬에서 테스팅 시, redis 호스트 명이 달라서 redis 컨테이너가 제대로 뜨지 않았습니다. 따라서 local 프로파일 설정 시 redis 호스트를 localhost로 덮어쓰도록 하였습니다.
- configuration의 active profiles에 아래와 같이 'local'을 적고 run하면 됩니다.
<img width="820" height="703" alt="Screenshot 2026-04-21 at 10 52 44 PM" src="https://github.com/user-attachments/assets/c091d816-8d49-473d-9e70-bed74834ffaf" />

### 🔥 관련 이슈
- closes #230
