### PR TITLE
feat(registration): /api/registrations/me 응답에 confirmedCount/waitlistCount 추가 및 registrationCnt 제거

### DIFF
--- a/src/main/kotlin/com/wafflestudio/spring2025/domain/registration/dto/response/GetMyRegistrationsResponse.kt
+++ b/src/main/kotlin/com/wafflestudio/spring2025/domain/registration/dto/response/GetMyRegistrationsResponse.kt
@@ -28,8 +28,10 @@ data class MyRegistrationItem(
     val registrationEndsAt: Instant?,
     @Schema(description = "정원")
     val capacity: Int?,
-    @Schema(description = "현재 신청 수 + 대기 수")
-    val registrationCnt: Int,
+    @Schema(description = "확정 참여자 수")
+    val confirmedCount: Int,
+    @Schema(description = "대기자 수")
+    val waitlistCount: Int,
     @Schema(description = "신청 상태")
     val status: MyRegistrationStatus,
     @Schema(description = "대기 순번 (WAITLISTED가 아니면 null)")
@@ -38,7 +40,8 @@ data class MyRegistrationItem(
     constructor(
         registration: Registration,
         event: Event,
-        registrationCnt: Int,
+        confirmedCount: Int,
+        waitlistCount: Int,
         waitlistedNum: Int?,
     ) : this(
         publicId = event.publicId,
@@ -48,7 +51,8 @@ data class MyRegistrationItem(
         registrationStartsAt = event.registrationStartsAt,
         registrationEndsAt = event.registrationEndsAt,
         capacity = event.capacity,
-        registrationCnt = registrationCnt,
+        confirmedCount = confirmedCount,
+        waitlistCount = waitlistCount,
         status = MyRegistrationStatus.from(registration.status),
         waitlistedNum = waitlistedNum,
     )

--- a/src/main/kotlin/com/wafflestudio/spring2025/domain/registration/service/RegistrationService.kt
+++ b/src/main/kotlin/com/wafflestudio/spring2025/domain/registration/service/RegistrationService.kt
@@ -337,11 +337,18 @@ RegistrationService(
                 event.id ?: throw EventNotFoundException()
             }
 
-        val countsByEventId =
+        val confirmedCountsByEventId =
             registrationRepository
                 .countByEventIdsAndStatuses(
                     eventIds = eventIds,
-                    statuses = listOf(RegistrationStatus.CONFIRMED, RegistrationStatus.WAITLISTED),
+                    statuses = listOf(RegistrationStatus.CONFIRMED),
+                ).associate { it.eventId to it.totalCount.toInt() }
+
+        val waitlistCountsByEventId =
+            registrationRepository
+                .countByEventIdsAndStatuses(
+                    eventIds = eventIds,
+                    statuses = listOf(RegistrationStatus.WAITLISTED),
                 ).associate { it.eventId to it.totalCount.toInt() }
 
         val waitlistedByRegistrationId =
@@ -362,7 +369,8 @@ RegistrationService(
                 MyRegistrationItem(
                     registration = registration,
                     event = event,
-                    registrationCnt = countsByEventId[registration.eventId] ?: 0,
+                    confirmedCount = confirmedCountsByEventId[registration.eventId] ?: 0,
+                    waitlistCount = waitlistCountsByEventId[registration.eventId] ?: 0,
                     waitlistedNum = waitlistedNumber,
                 )
             }

--- a/src/test/kotlin/com/wafflestudio/spring2025/RegistrationIntegrationTest.kt
+++ b/src/test/kotlin/com/wafflestudio/spring2025/RegistrationIntegrationTest.kt
@@ -705,6 +705,37 @@ class RegistrationIntegrationTest
                 .andExpect(jsonPath("$.registrations.length()").value(1))
         }
 
+        @Test
+        fun `my registrations endpoint includes confirmed and waitlist counts`() {
+            val (host, _) = dataGenerator.generateUser()
+            val (_, participantToken) = dataGenerator.generateUser()
+            val (_, anotherParticipantToken) = dataGenerator.generateUser()
+
+            val event =
+                createEvent(
+                    createdBy = host.id!!,
+                    title = "count-check",
+                    capacity = 1,
+                    waitlistEnabled = true,
+                )
+
+            registerAsUser(event.publicId, participantToken)
+            registerAsUser(event.publicId, anotherParticipantToken)
+
+            mvc
+                .perform(
+                    get("/api/registrations/me")
+                        .header("Authorization", "Bearer $participantToken")
+                        .param("page", "0")
+                        .param("size", "10")
+                        .contentType(MediaType.APPLICATION_JSON),
+                ).andExpect(status().isOk)
+                .andExpect(jsonPath("$.registrations.length()").value(1))
+                .andExpect(jsonPath("$.registrations[0].confirmedCount").value(1))
+                .andExpect(jsonPath("$.registrations[0].waitlistCount").value(1))
+                .andExpect(jsonPath("$.registrations[0].registrationCnt").doesNotExist())
+        }
+
         private fun registerAsUser(
             eventPublicId: String,
             token: String,


### PR DESCRIPTION
## ✨ Feature PR (to dev)

### 🧪 로컬 테스트 여부 (작업자 체크)
- [ ] 로컬에서 Swagger 혹은 테스트 코드로 동작을 확인했습니다.

### 📄 documentation 최신화 여부
> 변경사항과 관련된 API의 swagger documentation이 실제 동작과 일치하는지 확인합니다.
- [ ] (작업자) 확인하였습니다.
- [ ] (리뷰어) 확인하였습니다.

### 📌 작업 내용(what & why)

- GET /api/regisrations/me에서, 확정 참여자 수(confirmedCount)와 대기자 수(waitlistCount)를 응답에 포함
- GET /api/regisrations/me에서, registrationCnt 필드는 삭제

### 🔎 영향 범위                                                                                                                                                                     
- API 스펙 변경

### 📡 API 변경사항 (있다면)
- GET /api/regisrations/me에서, 확정 참여자 수(confirmedCount)와 대기자 수(waitlistCount)를 응답에 포함
- GET /api/regisrations/me에서, registrationCnt 필드는 삭제

| Method    | URL | 변경 내용 |
|-----------|-----|----------|
| GET | /api/registrations/me | confirmedCount 필드 추가 |
| GET | /api/registrations/me | waitlistCount 필드 추가 |
| GET | /api/registrations/me | registrationCnt 필드 삭제 |

### 🔥 관련 이슈
- closes #239
