### PR TITLE
쿼리 횟수 및 메모리 최적화

### DIFF
--- a/src/main/kotlin/com/wafflestudio/spring2025/domain/event/service/EventService.kt
+++ b/src/main/kotlin/com/wafflestudio/spring2025/domain/event/service/EventService.kt
@@ -121,17 +121,16 @@ class EventService(
                 .countByEventIdAndStatus(eventID = eventId, registrationStatus = RegistrationStatus.WAITLISTED)
                 .toInt()
 
-        val totalApplicants = confirmedCount + waitlistedCount
-
         val waitlistPosition: Int? =
             if (myReg?.status == RegistrationStatus.WAITLISTED) {
-                val waitlistedRegs =
-                    registrationRepository.findByEventIdAndStatusOrderByCreatedAtAsc(
-                        eventID = eventId,
-                        registrationStatus = RegistrationStatus.WAITLISTED,
-                    )
-                val idx = waitlistedRegs.indexOfFirst { it.id == myReg.id }
-                if (idx >= 0) idx + 1 else null
+                registrationRepository
+                    .findWaitlistPositionsByRegistrationPublicIds(
+                        eventId = eventId,
+                        status = RegistrationStatus.WAITLISTED,
+                        registrationPublicIds = listOf(myReg.registrationPublicId),
+                    ).firstOrNull()
+                    ?.waitlistNumber
+                    ?.toInt()
             } else {
                 null
             }

--- a/src/main/kotlin/com/wafflestudio/spring2025/domain/event/service/EventService.kt
+++ b/src/main/kotlin/com/wafflestudio/spring2025/domain/event/service/EventService.kt
@@ -271,19 +271,31 @@ class EventService(
         val sliced = fetched.take(pageSize)
         val nextCursor = sliced.lastOrNull()?.createdAt
 
+        val eventIds = sliced.map { requireNotNull(it.id) }
+
+        val confirmedCounts =
+            if (eventIds.isEmpty()) {
+                emptyMap()
+            } else {
+                registrationRepository
+                    .countByEventIdsAndStatuses(eventIds = eventIds, listOf(RegistrationStatus.CONFIRMED))
+                    .associate { it.eventId to it.totalCount.toInt() }
+            }
+
+        val waitlistedCounts =
+            if (eventIds.isEmpty()) {
+                emptyMap()
+            } else {
+                registrationRepository
+                    .countByEventIdsAndStatuses(eventIds = eventIds, listOf(RegistrationStatus.WAITLISTED))
+                    .associate { it.eventId to it.totalCount.toInt() }
+            }
+
         val responses =
             sliced.map { event ->
                 val eventId = requireNotNull(event.id)
-
-                val confirmedCount =
-                    registrationRepository
-                        .countByEventIdAndStatus(eventID = eventId, registrationStatus = RegistrationStatus.CONFIRMED)
-                        .toInt()
-
-                val waitlistedCount =
-                    registrationRepository
-                        .countByEventIdAndStatus(eventID = eventId, registrationStatus = RegistrationStatus.WAITLISTED)
-                        .toInt()
+                val confirmedCount = confirmedCounts[eventId] ?: 0
+                val waitlistedCount = waitlistedCounts[eventId] ?: 0
 
                 MyEventResponse(
                     publicId = event.publicId,

--- a/src/main/kotlin/com/wafflestudio/spring2025/domain/event/service/EventService.kt
+++ b/src/main/kotlin/com/wafflestudio/spring2025/domain/event/service/EventService.kt
@@ -96,10 +96,9 @@ class EventService(
         val event = getEventByPublicId(publicId)
         val eventId = requireNotNull(event.id) { "Event id is null: publicId=$publicId" }
 
-        val creatorUser =
-            userRepository.findById(event.createdBy).orElseThrow {
-                EventNotFoundException()
-            }
+        val userIdsToFetch = listOfNotNull(event.createdBy, requesterId).distinct()
+        val usersById = userRepository.findAllById(userIdsToFetch).associateBy { it.id!! }
+        val creatorUser = usersById[event.createdBy] ?: throw EventNotFoundException()
 
         val myReg =
             if (requesterId == null) {
@@ -149,10 +148,7 @@ class EventService(
                     }
             }
 
-        val viewerName: String? =
-            requesterId?.let {
-                userRepository.findById(it).orElse(null)?.name
-            }
+        val viewerName: String? = requesterId?.let { usersById[it]?.name }
 
         val viewer =
             if (viewerStatus == ViewerStatus.NONE) {

--- a/src/main/kotlin/com/wafflestudio/spring2025/domain/event/service/EventService.kt
+++ b/src/main/kotlin/com/wafflestudio/spring2025/domain/event/service/EventService.kt
@@ -23,6 +23,7 @@ import com.wafflestudio.spring2025.domain.registration.repository.RegistrationRe
 import com.wafflestudio.spring2025.domain.registration.service.WaitlistReconciliationService
 import com.wafflestudio.spring2025.domain.user.repository.UserRepository
 import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Pageable
 import org.springframework.data.domain.Sort
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -179,18 +180,17 @@ class EventService(
                 registrationEndsAt = event.registrationEndsAt,
             )
 
-        val confirmedRegs =
+        val previewRegs =
             registrationRepository.findByEventIdAndStatusOrderByCreatedAtAsc(
                 eventID = eventId,
                 registrationStatus = RegistrationStatus.CONFIRMED,
+                pageable = Pageable.ofSize(5),
             )
-
-        val previewRegs = confirmedRegs.take(5)
 
         val previewUserIds =
             previewRegs.mapNotNull { it.userId }.distinct()
 
-        val usersById =
+        val previewUsersById =
             userRepository.findAllById(previewUserIds).associateBy { it.id!! }
 
         val guestsPreview =
@@ -203,7 +203,7 @@ class EventService(
                         profileImage = null,
                     )
                 } else {
-                    usersById[uid]?.let {
+                    previewUsersById[uid]?.let {
                         GuestPreview(
                             id = it.id!!,
                             name = it.name,

--- a/src/main/kotlin/com/wafflestudio/spring2025/domain/event/service/EventService.kt
+++ b/src/main/kotlin/com/wafflestudio/spring2025/domain/event/service/EventService.kt
@@ -385,9 +385,10 @@ class EventService(
 
         // 알림 대상: CONFIRMED + WAITLISTED (BANNED 제외)
         val registrationsToNotify =
-            registrationRepository
-                .findByEventId(eventId)
-                .filter { it.status == RegistrationStatus.CONFIRMED || it.status == RegistrationStatus.WAITLISTED }
+            registrationRepository.findByEventIdAndStatusIn(
+                eventID = eventId,
+                statuses = listOf(RegistrationStatus.CONFIRMED, RegistrationStatus.WAITLISTED),
+            )
 
         // 이메일 데이터 구성 (삭제 전에 user 정보 조회)
         val hostUser = userRepository.findById(event.createdBy).orElse(null)

--- a/src/main/kotlin/com/wafflestudio/spring2025/domain/registration/repository/RegistrationRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/spring2025/domain/registration/repository/RegistrationRepository.kt
@@ -41,6 +41,11 @@ interface RegistrationRepository :
         eventId: Long,
     ): Registration?
 
+    fun findByEventIdAndStatusIn(
+        eventID: Long,
+        statuses: Collection<RegistrationStatus>,
+    ): List<Registration>
+
     fun countByEventId(eventID: Long): Long
 
     fun countByEventIdAndStatus(
@@ -64,6 +69,12 @@ interface RegistrationRepository :
     fun findByEventIdAndStatusOrderByCreatedAtAsc(
         eventID: Long,
         registrationStatus: RegistrationStatus,
+    ): List<Registration>
+
+    fun findByEventIdAndStatusOrderByCreatedAtAsc(
+        eventID: Long,
+        registrationStatus: RegistrationStatus,
+        pageable: Pageable,
     ): List<Registration>
 
     @Query(

--- a/src/main/kotlin/com/wafflestudio/spring2025/domain/registration/repository/RegistrationRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/spring2025/domain/registration/repository/RegistrationRepository.kt
@@ -186,7 +186,7 @@ interface RegistrationRepository :
                ranked.waitlist_number AS waitlist_number
         FROM (
             SELECT r.registration_public_id,
-                   ROW_NUMBER() OVER (ORDER BY r.created_at ASC, r.registration_public_id ASC) AS waitlist_number
+                   ROW_NUMBER() OVER (ORDER BY r.created_at ASC, r.id ASC) AS waitlist_number
             FROM registrations r
             WHERE r.event_id = :eventId AND r.status = :status
         ) ranked

--- a/src/main/kotlin/com/wafflestudio/spring2025/domain/registration/service/RegistrationService.kt
+++ b/src/main/kotlin/com/wafflestudio/spring2025/domain/registration/service/RegistrationService.kt
@@ -97,6 +97,11 @@ RegistrationService(
                 registrationRepository.findByUserIdAndEventId(userId, eventPk)
             }
 
+        val userIdsToFetch = listOfNotNull(lockedEvent.createdBy, userId).distinct()
+        val fetchedUsersById = userRepository.findAllById(userIdsToFetch).associateBy { it.id!! }
+        val hostEmail = fetchedUsersById[lockedEvent.createdBy]?.email
+        val user = userId?.let { fetchedUsersById[it] }
+
         val saved =
             try {
                 if (existingRegistration != null) {
@@ -113,8 +118,7 @@ RegistrationService(
                         -> throw RegistrationConflictException(RegistrationErrorCode.REGISTRATION_ALREADY_EXISTS)
                     }
                 } else {
-                    val hostEmail = userRepository.findById(lockedEvent.createdBy).orElse(null)?.email
-                    val registrationEmail = userId?.let { userRepository.findById(it).orElse(null)?.email } ?: guestEmail
+                    val registrationEmail = user?.email ?: guestEmail
 
                     if (hostEmail != null && hostEmail == registrationEmail) {
                         throw RegistrationValidationException(RegistrationErrorCode.REGISTRATION_BLOCKED_HOST)

--- a/src/main/kotlin/com/wafflestudio/spring2025/domain/registration/service/RegistrationService.kt
+++ b/src/main/kotlin/com/wafflestudio/spring2025/domain/registration/service/RegistrationService.kt
@@ -253,8 +253,6 @@ RegistrationService(
             }
         }
 
-        eventLockRepository.lockById(registration.eventId)
-
         if (!isRegistrationEnabled(event)) {
             throw RegistrationValidationException(RegistrationErrorCode.NOT_WITHIN_REGISTRATION_WINDOW)
         }

--- a/src/main/kotlin/com/wafflestudio/spring2025/domain/registration/service/RegistrationService.kt
+++ b/src/main/kotlin/com/wafflestudio/spring2025/domain/registration/service/RegistrationService.kt
@@ -148,19 +148,11 @@ RegistrationService(
                 throw RegistrationConflictException(RegistrationErrorCode.REGISTRATION_ALREADY_EXISTS)
             }
 
-        val waitlistedNumber: Int? =
-            if (saved.status == RegistrationStatus.WAITLISTED) {
-                registrationRepository
-                    .countByEventIdAndStatus(eventPk, RegistrationStatus.WAITLISTED)
-                    .toInt()
-            } else {
-                null
-            }
-
-        val user =
-            userId?.let { id ->
-                userRepository.findById(id).orElse(null)
-            }
+        val waitlistedCount =
+            registrationRepository
+                .countByEventIdAndStatus(eventPk, RegistrationStatus.WAITLISTED)
+                .toInt()
+        val waitlistedNumber: Int? = if (saved.status == RegistrationStatus.WAITLISTED) waitlistedCount else null
 
         val recipientEmail = user?.email ?: guestEmail
 
@@ -168,10 +160,6 @@ RegistrationService(
             val confirmedCount =
                 registrationRepository
                     .countByEventIdAndStatus(eventPk, RegistrationStatus.CONFIRMED)
-                    .toInt()
-            val waitlistedCount =
-                registrationRepository
-                    .countByEventIdAndStatus(eventPk, RegistrationStatus.WAITLISTED)
                     .toInt()
             val totalCount = confirmedCount + waitlistedCount
 

--- a/src/main/kotlin/com/wafflestudio/spring2025/domain/registration/service/RegistrationService.kt
+++ b/src/main/kotlin/com/wafflestudio/spring2025/domain/registration/service/RegistrationService.kt
@@ -769,12 +769,12 @@ RegistrationService(
         val remainingWaitlisted = totalWaitlisted - promoted.size
         val totalCount = confirmedAfter + remainingWaitlisted
 
+        val promotedUserIds = promoted.mapNotNull { it.userId }.distinct()
+        val promotedUsersById = userRepository.findAllById(promotedUserIds).associateBy { it.id!! }
+
         val emailDataList =
             promoted.mapNotNull { registration ->
-                val user: User? =
-                    registration.userId?.let { uid ->
-                        userRepository.findById(uid).orElse(null)
-                    }
+                val user: User? = registration.userId?.let { promotedUsersById[it] }
 
                 val recipientEmail = user?.email ?: registration.guestEmail
                 val recipientName = user?.name ?: registration.guestName ?: "참여자"

--- a/src/main/kotlin/com/wafflestudio/spring2025/domain/registration/service/RegistrationService.kt
+++ b/src/main/kotlin/com/wafflestudio/spring2025/domain/registration/service/RegistrationService.kt
@@ -576,13 +576,14 @@ RegistrationService(
         val status = registration.status
         val waitlistPosition =
             if (status == RegistrationStatus.WAITLISTED) {
-                val waitlistedRegs =
-                    registrationRepository.findByEventIdAndStatusOrderByCreatedAtAsc(
-                        registration.eventId,
-                        RegistrationStatus.WAITLISTED,
-                    )
-                val idx = waitlistedRegs.indexOfFirst { it.id == registration.id }
-                if (idx >= 0) idx + 1 else 0
+                registrationRepository
+                    .findWaitlistPositionsByRegistrationPublicIds(
+                        eventId = registration.eventId,
+                        status = RegistrationStatus.WAITLISTED,
+                        registrationPublicIds = listOf(registration.registrationPublicId),
+                    ).firstOrNull()
+                    ?.waitlistNumber
+                    ?.toInt() ?: 0
             } else {
                 0
             }

--- a/src/main/kotlin/com/wafflestudio/spring2025/domain/registration/service/RegistrationService.kt
+++ b/src/main/kotlin/com/wafflestudio/spring2025/domain/registration/service/RegistrationService.kt
@@ -28,6 +28,7 @@ import com.wafflestudio.spring2025.domain.user.model.User
 import com.wafflestudio.spring2025.domain.user.repository.UserRepository
 import org.springframework.dao.DuplicateKeyException
 import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import org.springframework.transaction.support.TransactionSynchronization
@@ -755,23 +756,26 @@ RegistrationService(
         val available = capacity - confirmed
         if (available <= 0) return
 
-        val waitlistedRegs =
+        val totalWaitlisted =
+            registrationRepository.countByEventIdAndStatus(eventId, RegistrationStatus.WAITLISTED).toInt()
+
+        val promoted =
             registrationRepository.findByEventIdAndStatusOrderByCreatedAtAsc(
                 eventId,
                 RegistrationStatus.WAITLISTED,
+                Pageable.ofSize(available),
             )
 
         val waitlistNumbers =
-            waitlistedRegs.withIndex().associate { indexed ->
-                indexed.value.registrationPublicId to (indexed.index + 1)
+            promoted.withIndex().associate { (index, reg) ->
+                reg.registrationPublicId to (index + 1)
             }
 
-        val promoted = waitlistedRegs.take(available)
         promoted.forEach { it.status = RegistrationStatus.CONFIRMED }
         registrationRepository.saveAll(promoted)
 
         val confirmedAfter = confirmed + promoted.size
-        val remainingWaitlisted = waitlistedRegs.size - promoted.size
+        val remainingWaitlisted = totalWaitlisted - promoted.size
         val totalCount = confirmedAfter + remainingWaitlisted
 
         val emailDataList =


### PR DESCRIPTION
## ✨ Feature PR (to dev)

### 🧪 로컬 테스트 여부 (작업자 체크)
- [x] 로컬에서 Swagger 혹은 테스트 코드로 동작을 확인했습니다.

### 📄 documentation 최신화 여부
> 변경사항과 관련된 API의 swagger documentation이 실제 동작과 일치하는지 확인합니다.
- [ ] (작업자) 확인하였습니다.
- [ ] (리뷰어) 확인하였습니다.

### 📌 작업 내용(what & why)

반복문 혹은 중복 조회로 인한 불필요한 쿼리 횟수를 줄이는 작업과, 메모리에 불필요하게 많은 데이터를 로드하던 부분에서 딱 필요한 만큼만 불러오도록 하는 메모리 최적화를 동시에 진행하였습니다. 쿼리 횟수를 줄여 처리 처리속도가 개선되면 간접적으로 메모리 부하도 줄어들 것으로 기대합니다.

## EventService                                                                                                                                                               
- getDetail(): 대기 순번 계산 시 전체 WAITLISTED 로드 대신 window function 쿼리로 1행만 조회 [쿼리 횟수 최적화]
- getDetail(): CONFIRMED 전체 로드 후 take(5) 대신 Pageable.ofSize(5)로 DB에서 5행만 반환 [메모리 최적화]                
- getDetail(): createdBy, requesterId 각각 findById 2회 → findAllById 1회로 통합 [쿼리 횟수 최적화]                                                                                              
- getMyEventsInfinite(): 이벤트 N개 × count 2회(2N 쿼리) → countByEventIdsAndStatuses 배치 2회로 감소 [쿼리 횟수 최적화]                                                                          - delete(): 전체 registration 로드 후 애플리케이션 filter → findByEventIdAndStatusIn으로 DB 측 필터링 [메모리 최적화]                                                                         
                                                                                                                                                                                
## RegistrationService                                                                                                                                                        
- getRegistrationInformation(): 전체 WAITLISTED 로드 후 indexOfFirst → window function 쿼리로 1행만 조회 [메모리 최적화]                                                                      
- reconcileWaitlist(): 전체 대기자 로드 대신 Pageable.ofSize(available)로 승격 대상만 로드 [메모리 최적화]                                                                                    
- reconcileWaitlist(): 루프 내 findById N회 → findAllById 배치 처리 1회 [쿼리 횟수 최적화]                                                                                                           
- create(): host·user findById 최대 3회 → findAllById 1회로 통합 [쿼리 횟수 최적화]                                                                                                             
- create(): countByEventIdAndStatus(WAITLISTED) 2회 중복 → 1회 계산 후 재사용 [쿼리 횟수 최적화]    

### 🔥 관련 이슈
- closes #241
