### PR TITLE
feat: prometheus 모니터링 설정 추가

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -44,7 +44,6 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-webflux")
     implementation("org.springframework.boot:spring-boot-starter-data-jdbc")
     implementation("org.springframework.boot:spring-boot-starter-data-redis")
-    implementation("org.springframework.boot:spring-boot-starter-actuator")
     implementation("org.springframework.boot:spring-boot-starter-mail")
     implementation("org.mindrot:jbcrypt:0.4")
     implementation("io.jsonwebtoken:jjwt-api:0.11.5")
@@ -73,6 +72,10 @@ dependencies {
     // OCI Vault - SDK 직접 사용 (waffle-oci-vault 2.1.0은 Spring Boot 3.5와 호환 안됨)
     implementation("com.oracle.oci.sdk:oci-java-sdk-secrets:3.80.1")
     implementation("com.oracle.oci.sdk:oci-java-sdk-common-httpclient-jersey3:3.80.1")
+
+    // prometheus 의존성 추가
+    implementation("org.springframework.boot:spring-boot-starter-actuator")
+    implementation("io.micrometer:micrometer-registry-prometheus")
 }
 
 kotlin {

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -76,6 +76,23 @@ services:
         limits:
           memory: 64M
 
+  prometheus:
+    image: prom/prometheus:latest
+    container_name: prometheus-dev
+    restart: unless-stopped
+    ports:
+      - "127.0.0.1:9090:9090"
+    volumes:
+      - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - prometheus_data_dev:/prometheus
+    command:
+      - "--config.file=/etc/prometheus/prometheus.yml"
+      - "--storage.tsdb.path=/prometheus"
+    depends_on:
+      app:
+        condition: service_healthy
+
 volumes:
   mysql_data_dev:
   redis_data_dev:
+  prometheus_data_dev:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -68,7 +68,7 @@ management:
   endpoints:
     web:
       exposure:
-        include: health
+        include: health,info,prometheus,metrics
   endpoint:
     health:
       show-details: always


### PR DESCRIPTION
## ✨ Feature PR (to dev)

### 🧪 로컬 테스트 여부 (작업자 체크)
- [ ] 로컬에서 Swagger 혹은 테스트 코드로 동작을 확인했습니다.
- [ ] API 변경이 있다면 `src/main/resources/static/docs/openapi.yaml`을 함께 갱신했습니다.
- [ ] `/docs/swagger-ui.html`에서 변경 API가 의도대로 보이는지 확인했습니다.

### 📄 documentation 최신화 여부
> 변경사항과 관련된 API의 swagger documentation이 실제 동작과 일치하는지 확인합니다.
- [ ] (작업자) 확인하였습니다.
- [ ] (리뷰어) 확인하였습니다.

### 📌 작업 내용(what & why)
- Spring Boot Actuator 및 Micrometer Prometheus registry 의존성 추가
- docker-compose.dev에 prometheus 서비스/볼륨 구성 추가
- management endpoint 노출 범위에 info, metrics, prometheus 추가

### 🔎 영향 범위
- 환경 변수 추가/변경
