### PR TITLE
Chore/243 로깅 시스템 추가

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -40,6 +40,7 @@ repositories {
 }
 
 dependencies {
+    implementation("org.springframework.boot:spring-boot-starter-aop")
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("org.springframework.boot:spring-boot-starter-webflux")
     implementation("org.springframework.boot:spring-boot-starter-data-jdbc")

--- a/src/main/kotlin/com/wafflestudio/spring2025/common/aop/LoggingAspect.kt
+++ b/src/main/kotlin/com/wafflestudio/spring2025/common/aop/LoggingAspect.kt
@@ -1,0 +1,20 @@
+package com.wafflestudio.spring2025.common.aop
+
+import org.aspectj.lang.annotation.AfterThrowing
+import org.aspectj.lang.annotation.Aspect
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+
+@Aspect
+@Component
+class LoggingAspect {
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    @AfterThrowing(
+        pointcut = "within(com.wafflestudio.spring2025.domain..service..*)",
+        throwing = "ex",
+    )
+    fun logException(ex: Throwable) {
+        log.error("Unhandled exception in service", ex)
+    }
+}

--- a/src/main/kotlin/com/wafflestudio/spring2025/common/aop/LoggingAspect.kt
+++ b/src/main/kotlin/com/wafflestudio/spring2025/common/aop/LoggingAspect.kt
@@ -1,5 +1,6 @@
 package com.wafflestudio.spring2025.common.aop
 
+import com.wafflestudio.spring2025.common.exception.DomainException
 import org.aspectj.lang.annotation.AfterThrowing
 import org.aspectj.lang.annotation.Aspect
 import org.slf4j.LoggerFactory
@@ -15,6 +16,10 @@ class LoggingAspect {
         throwing = "ex",
     )
     fun logException(ex: Throwable) {
-        log.error("Unhandled exception in service", ex)
+        if (ex is DomainException && ex.httpErrorCode.is4xxClientError) {
+            log.warn("Expected domain exception: {}", ex.toString())
+        } else {
+            log.error("Unhandled exception in service", ex)
+        }
     }
 }

--- a/src/main/kotlin/com/wafflestudio/spring2025/common/filter/RequestIdFilter.kt
+++ b/src/main/kotlin/com/wafflestudio/spring2025/common/filter/RequestIdFilter.kt
@@ -1,0 +1,30 @@
+package com.wafflestudio.spring2025.common.filter
+
+import jakarta.servlet.FilterChain
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.slf4j.MDC
+import org.springframework.core.Ordered
+import org.springframework.core.annotation.Order
+import org.springframework.stereotype.Component
+import org.springframework.web.filter.OncePerRequestFilter
+import java.util.UUID
+
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE)
+class RequestIdFilter : OncePerRequestFilter() {
+    override fun doFilterInternal(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        filterChain: FilterChain,
+    ) {
+        val requestId = UUID.randomUUID().toString()
+        MDC.put("requestId", requestId)
+        response.setHeader("X-Request-Id", requestId)
+        try {
+            filterChain.doFilter(request, response)
+        } finally {
+            MDC.remove("requestId")
+        }
+    }
+}

--- a/src/main/kotlin/com/wafflestudio/spring2025/domain/auth/AuthenticationInterceptor.kt
+++ b/src/main/kotlin/com/wafflestudio/spring2025/domain/auth/AuthenticationInterceptor.kt
@@ -17,11 +17,7 @@ class AuthenticationInterceptor : HandlerInterceptor {
         response: HttpServletResponse,
         handler: Any,
     ): Boolean {
-        logger.info("AuthenticationInterceptor pre-handle")
-
         val handlerMethod = handler as? HandlerMethod ?: return true
-        logger.info(handlerMethod.toString())
-
         val authRequired =
             handlerMethod.hasMethodAnnotation(AuthRequired::class.java) ||
                 handlerMethod.beanType.isAnnotationPresent(AuthRequired::class.java)

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -132,3 +132,14 @@ oci:
   vault:
     secret-ids: ocid1.vaultsecret.oc1.ap-chuncheon-1.amaaaaaat2m5lbqameflpkt7abivvrauqwheybzrkqipf7msv3ol6ikhd3aq
     region: ap-chuncheon-1
+logging:
+  level:
+    org:
+      springframework:
+        data:
+          jdbc: INFO
+        jdbc:
+          core:
+            JdbcTemplate: INFO
+            namedparam:
+              NamedParameterJdbcTemplate: INFO

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <property name="PATTERN"
+              value="%d{yyyy-MM-dd HH:mm:ss.SSS} [%X{requestId:-}] %-5level %logger{36} - %msg%n"/>
+
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>${PATTERN}</pattern>
+        </encoder>
+    </appender>
+
+    <!-- prod 외 (local, dev): 큐가 가득 차도 로그 버리지 않음 -->
+    <springProfile name="!prod">
+        <appender name="ASYNC" class="ch.qos.logback.classic.AsyncAppender">
+            <discardingThreshold>0</discardingThreshold>
+            <appender-ref ref="CONSOLE"/>
+        </appender>
+        <logger name="com.wafflestudio.spring2025" level="DEBUG"/>
+        <root level="INFO"><appender-ref ref="ASYNC"/></root>
+    </springProfile>
+
+    <!-- prod: 큐 80% 이상 시 DEBUG/INFO 버림 (기본값), 앱 코드 INFO -->
+    <springProfile name="prod">
+        <appender name="ASYNC" class="ch.qos.logback.classic.AsyncAppender">
+            <appender-ref ref="CONSOLE"/>
+        </appender>
+        <logger name="com.wafflestudio.spring2025" level="INFO"/>
+        <root level="WARN"><appender-ref ref="ASYNC"/></root>
+    </springProfile>
+</configuration>


### PR DESCRIPTION
## ✨ Feature PR (to dev)

### 🧪 로컬 테스트 여부 (작업자 체크)
- [ ] 로컬에서 Swagger 혹은 테스트 코드로 동작을 확인했습니다.
- [ ] API 변경이 있다면 `src/main/resources/static/docs/openapi.yaml`을 함께 갱신했습니다.
- [ ] `/docs/swagger-ui.html`에서 변경 API가 의도대로 보이는지 확인했습니다.

### 📄 documentation 최신화 여부
> 변경사항과 관련된 API의 swagger documentation이 실제 동작과 일치하는지 확인합니다.
- [ ] (작업자) 확인하였습니다.
- [ ] (리뷰어) 확인하였습니다.

### 📌 작업 내용(what & why)

  RequestId 추적
  - 요청마다 UUID를 생성해 MDC에 주입하는 RequestIdFilter 추가
  - 모든 로그에 [requestId] 포함, 응답 헤더 X-Request-Id로도 노출
  
  LoggingAspect
  - 서비스 레이어에서 발생하는 예외를 AOP로 일괄 수집
  - DomainException 중 4xx (유저가 잘못된 값을 줘서 예외가 발생하는 게 정상인 경우) → 콜스택 없이 WARN 한 줄만 출력
  - 5xx DomainException 및 그 외 → ERROR + 콜스택 출력

  logback 설정
  - 비동기 appender(AsyncAppender) 적용으로 로깅 I/O가 요청 처리에 영향을 주지 않도록 구성
  - prod 프로파일: 큐 80% 초과 시 DEBUG/INFO 자동 드롭, 최소 레벨 INFO (메모리 영향 최소화하기 위함)
  - 비prod 프로파일(dev, local 등): 로그 드롭 없음, 최소 레벨 DEBUG 
  - prod에서 Spring JDBC 쿼리 로그 레벨 INFO로 고정


### 🔎 영향 범위
  <!-- 해당하는 항목만 남기고 나머지는 삭제해주세요 -->                                                                                                                                                                                    
- API 스펙 변경

### 📡 API 변경사항 (있다면)

모든 응답 Header에 X-Request-Id 추가

### 🔥 관련 이슈
- closes #243
