### PR TITLE
257 메일 템플릿 정원 표시 형식 통일

### DIFF
--- a/src/main/kotlin/com/wafflestudio/spring2025/common/email/service/EmailService.kt
+++ b/src/main/kotlin/com/wafflestudio/spring2025/common/email/service/EmailService.kt
@@ -120,6 +120,7 @@ class EmailService(
         val endsAt: Instant?,
         val location: String?,
         val newCapacity: Int,
+        val totalCount: Int,
         val registrationStartsAt: Instant?,
         val registrationEndsAt: Instant,
         val description: String?,
@@ -138,8 +139,7 @@ class EmailService(
                         .replace("{eventTitle}", formatEventTitle(data.eventTitle))
                         .replace("{eventDateRange}", formatEventDateRange(data.startsAt, data.endsAt, "-"))
                         .replace("{location}", formatLocation(data.location))
-                        .replace("{totalCount}", data.totalCount?.toString() ?: "null")
-                        .replace("{capacity}", data.capacity?.toString() ?: "null")
+                        .replace("{capacityDisplay}", formatCapacity(data.totalCount, data.capacity))
                         .replace(
                             "{registrationDateRange}",
                             formatRegistrationDateRange(data.registrationStartsAt, data.registrationEndsAt),
@@ -165,8 +165,7 @@ class EmailService(
                         .replace("{eventTitle}", formatEventTitle(data.eventTitle))
                         .replace("{eventDateRange}", formatEventDateRange(data.startsAt, data.endsAt, "-"))
                         .replace("{location}", formatLocation(data.location))
-                        .replace("{totalCount}", data.totalCount?.toString() ?: "null")
-                        .replace("{capacity}", data.capacity?.toString() ?: "null")
+                        .replace("{capacityDisplay}", formatCapacity(data.totalCount, data.capacity))
                         .replace(
                             "{registrationDateRange}",
                             formatRegistrationDateRange(data.registrationStartsAt, data.registrationEndsAt),
@@ -189,8 +188,7 @@ class EmailService(
                         .replace("{eventTitle}", formatEventTitle(data.eventTitle))
                         .replace("{eventDateRange}", formatEventDateRange(data.startsAt, data.endsAt, "-"))
                         .replace("{location}", formatLocation(data.location))
-                        .replace("{totalCount}", data.totalCount?.toString() ?: "null")
-                        .replace("{capacity}", data.capacity?.toString() ?: "null")
+                        .replace("{capacityDisplay}", formatCapacity(data.totalCount, data.capacity))
                         .replace(
                             "{registrationDateRange}",
                             formatRegistrationDateRange(data.registrationStartsAt, data.registrationEndsAt),
@@ -217,8 +215,7 @@ class EmailService(
                 .replace("{eventTitle}", formatEventTitle(data.eventTitle))
                 .replace("{eventDateRange}", formatEventDateRange(data.startsAt, data.endsAt, "-"))
                 .replace("{location}", formatLocation(data.location))
-                .replace("{totalCount}", data.totalCount?.toString() ?: "null")
-                .replace("{capacity}", data.capacity?.toString() ?: "null")
+                .replace("{capacityDisplay}", formatCapacity(data.totalCount, data.capacity))
                 .replace(
                     "{registrationDateRange}",
                     formatRegistrationDateRange(data.registrationStartsAt, data.registrationEndsAt),
@@ -258,7 +255,7 @@ class EmailService(
                 .replace("{serviceDomain}", emailConfig.serviceDomain)
                 .replace("{name}", data.name)
                 .replace("{waitingNum}", data.waitingNum?.toString() ?: "-")
-                .replace("{newCapacity}", data.newCapacity.toString())
+                .replace("{capacityDisplay}", formatCapacity(data.totalCount, data.newCapacity))
                 .replace("{eventTitle}", formatEventTitle(data.eventTitle))
                 .replace("{eventDateRange}", formatEventDateRange(data.startsAt, data.endsAt, "-"))
                 .replace("{location}", formatLocation(data.location))
@@ -302,8 +299,7 @@ class EmailService(
                 .replace("{eventTitle}", formatEventTitle(eventTitle))
                 .replace("{eventDateRange}", formatEventDateRange(startsAt, endsAt, "~"))
                 .replace("{location}", formatLocation(location))
-                .replace("{totalCount}", totalCount?.toString() ?: "null")
-                .replace("{capacity}", capacity?.toString() ?: "null")
+                .replace("{capacityDisplay}", formatCapacity(totalCount, capacity))
                 .replace(
                     "{registrationDateRange}",
                     formatRegistrationDateRange(registrationStartsAt, registrationEndsAt),
@@ -365,6 +361,20 @@ class EmailService(
             startText.isNullOrBlank() -> endText ?: ""
             endText.isNullOrBlank() -> startText
             else -> "$startText-$endText"
+        }
+    }
+
+    private fun formatCapacity(
+        totalCount: Int?,
+        capacity: Int?,
+    ): String {
+        if (capacity == null) return "${totalCount ?: "-"}명"
+        val confirmed = if (totalCount != null) minOf(totalCount, capacity) else capacity
+        val waitlisted = if (totalCount != null) maxOf(0, totalCount - capacity) else 0
+        return if (waitlisted > 0) {
+            "$confirmed/${capacity}명 (대기자 ${waitlisted}명)"
+        } else {
+            "$confirmed/${capacity}명"
         }
     }
 

--- a/src/main/kotlin/com/wafflestudio/spring2025/common/email/service/EmailService.kt
+++ b/src/main/kotlin/com/wafflestudio/spring2025/common/email/service/EmailService.kt
@@ -99,6 +99,7 @@ class EmailService(
         val registrationStartsAt: Instant?,
         val registrationEndsAt: Instant?,
         val description: String?,
+        val publicId: String?,
     )
 
     data class EventCancellationEmailData(
@@ -211,6 +212,7 @@ class EmailService(
     fun sendRegistrationDeleteEmail(data: RegistrationDeleteEmailData) {
         val htmlContent =
             loadTemplate("registration-delete.html")
+                .replace("{serviceDomain}", emailConfig.serviceDomain)
                 .replace("{name}", data.name)
                 .replace("{eventTitle}", formatEventTitle(data.eventTitle))
                 .replace("{eventDateRange}", formatEventDateRange(data.startsAt, data.endsAt, "-"))
@@ -220,6 +222,7 @@ class EmailService(
                     "{registrationDateRange}",
                     formatRegistrationDateRange(data.registrationStartsAt, data.registrationEndsAt),
                 ).replace("{description}", formatDescription(data.description))
+                .replace("{publicId}", data.publicId ?: "-")
 
         sendHtmlEmail(
             to = data.toEmail,

--- a/src/main/kotlin/com/wafflestudio/spring2025/domain/registration/service/RegistrationService.kt
+++ b/src/main/kotlin/com/wafflestudio/spring2025/domain/registration/service/RegistrationService.kt
@@ -673,6 +673,9 @@ RegistrationService(
         toDemote.forEach { it.status = RegistrationStatus.WAITLISTED }
         registrationRepository.saveAll(toDemote)
 
+        val waitlistedCount = registrationRepository.countByEventIdAndStatus(eventId, RegistrationStatus.WAITLISTED).toInt()
+        val totalCount = newCapacity + waitlistedCount
+
         val demotedPublicIds = toDemote.map { it.registrationPublicId }
         val waitlistPositions =
             registrationRepository
@@ -698,6 +701,7 @@ RegistrationService(
                     endsAt = event.endsAt,
                     location = event.location,
                     newCapacity = newCapacity,
+                    totalCount = totalCount,
                     registrationStartsAt = event.registrationStartsAt,
                     registrationEndsAt = event.registrationEndsAt,
                     description = event.description,

--- a/src/main/kotlin/com/wafflestudio/spring2025/domain/registration/service/RegistrationService.kt
+++ b/src/main/kotlin/com/wafflestudio/spring2025/domain/registration/service/RegistrationService.kt
@@ -273,6 +273,7 @@ RegistrationService(
                     registrationStartsAt = event.registrationStartsAt,
                     registrationEndsAt = event.registrationEndsAt,
                     description = event.description,
+                    publicId = event.publicId,
                 )
 
             afterCommit {

--- a/src/main/resources/com/wafflestudio/spring2025/common/email/template/registration-banned.html
+++ b/src/main/resources/com/wafflestudio/spring2025/common/email/template/registration-banned.html
@@ -73,7 +73,7 @@
                                      alt="user" width="20" style="display: block; border: 0;">
                             </td>
                             <td style="padding-bottom: 4px; padding-left: 10px; vertical-align: middle;">
-                                정원 <span style="margin-left:8px; color:#444;">{totalCount}/{capacity}명</span>
+                                정원 <span style="margin-left:8px; color:#444;">{capacityDisplay}</span>
                             </td>
                         </tr>
                     </table>

--- a/src/main/resources/com/wafflestudio/spring2025/common/email/template/registration-confirmed.html
+++ b/src/main/resources/com/wafflestudio/spring2025/common/email/template/registration-confirmed.html
@@ -37,6 +37,7 @@
             </tr>
         </table>
 
+        <a href="{serviceDomain}/event/{publicId}?regId={registrationPublicId}" style="display: block; text-decoration: none; color: inherit;">
         <div style="border: 1px solid #EAEAEA; border-radius: 12px; padding: 24px; margin-bottom: 16px;">
             <div style="font-size: 22px; font-weight: bold; color: #000; margin-bottom: 20px;">{eventTitle}</div>
 
@@ -74,6 +75,7 @@
                 style="text-align: right; color: #CCCCCC; font-size: 24px; line-height: 1; font-family: sans-serif; font-weight: 300; margin-top: -10px;">
                 &rsaquo;</div>
         </div>
+        </a>
 
         <table border="0" cellpadding="0" cellspacing="0"
             style="width: 100%; background-color: #F7F8F9; border-radius: 8px; margin-bottom: 40px;">

--- a/src/main/resources/com/wafflestudio/spring2025/common/email/template/registration-confirmed.html
+++ b/src/main/resources/com/wafflestudio/spring2025/common/email/template/registration-confirmed.html
@@ -66,7 +66,7 @@
                              alt="user" width="18" style="display: block; border: 0;">
                     </td>
                     <td style="padding-bottom: 4px; padding-left: 10px; vertical-align: middle;">
-                        정원 <span style="margin-left:8px; color:#444;">{totalCount}/{capacity}명</span>
+                        정원 <span style="margin-left:8px; color:#444;">{capacityDisplay}</span>
                     </td>
                 </tr>
             </table>

--- a/src/main/resources/com/wafflestudio/spring2025/common/email/template/registration-delete.html
+++ b/src/main/resources/com/wafflestudio/spring2025/common/email/template/registration-delete.html
@@ -74,7 +74,7 @@
                                  alt="user" width="20" style="display: block; border: 0;">
                         </td>
                         <td style="padding-bottom: 4px; padding-left: 10px; vertical-align: middle;">
-                            정원 <span style="margin-left:8px; color:#444;">{totalCount}/{capacity}명</span>
+                            정원 <span style="margin-left:8px; color:#444;">{capacityDisplay}</span>
                         </td>
                     </tr>
                 </table>

--- a/src/main/resources/com/wafflestudio/spring2025/common/email/template/registration-delete.html
+++ b/src/main/resources/com/wafflestudio/spring2025/common/email/template/registration-delete.html
@@ -44,6 +44,7 @@
                 </tr>
             </table>
 
+            <a href="{serviceDomain}/event/{publicId}" style="display: block; text-decoration: none; color: inherit;">
             <div style="border: 1px solid #EAEAEA; border-radius: 12px; padding: 24px; margin-bottom: 16px;">
                 <div style="font-size: 20px; font-weight: bold; color: #000; margin-bottom: 20px;">{eventTitle}
                 </div>
@@ -82,6 +83,7 @@
                         style="text-align: right; color: #CCCCCC; font-size: 24px; line-height: 1; font-family: sans-serif; font-weight: 300; margin-top: -10px;">
                     &rsaquo;</div>
             </div>
+            </a>
 
             <table border="0" cellpadding="0" cellspacing="0" width="100%"
                    style="background-color: #F7F8F9; border-radius: 8px; margin-bottom: 30px;">

--- a/src/main/resources/com/wafflestudio/spring2025/common/email/template/registration-demoted.html
+++ b/src/main/resources/com/wafflestudio/spring2025/common/email/template/registration-demoted.html
@@ -44,6 +44,7 @@
                     </tr>
                 </table>
 
+                <a href="{serviceDomain}/event/{publicId}?regId={registrationPublicId}" style="display: block; text-decoration: none; color: inherit;">
                 <div style="border: 1px solid #EAEAEA; border-radius: 12px; padding: 24px; margin-bottom: 16px;">
                     <div style="font-size: 20px; font-weight: bold; color: #000; margin-bottom: 20px;">{eventTitle}
                     </div>
@@ -82,6 +83,7 @@
                         style="text-align: right; color: #CCCCCC; font-size: 24px; line-height: 1; font-family: sans-serif; font-weight: 300; margin-top: -10px;">
                         &rsaquo;</div>
                 </div>
+                </a>
 
                 <table border="0" cellpadding="0" cellspacing="0" width="100%"
                     style="background-color: #F7F8F9; border-radius: 8px; margin-bottom: 30px;">

--- a/src/main/resources/com/wafflestudio/spring2025/common/email/template/registration-demoted.html
+++ b/src/main/resources/com/wafflestudio/spring2025/common/email/template/registration-demoted.html
@@ -74,7 +74,7 @@
                                      alt="user" width="18" style="display: block; border: 0;">
                             </td>
                             <td style="padding-bottom: 4px; padding-left: 10px; vertical-align: middle;">
-                                정원 <span style="margin-left:8px; color:#444;">{newCapacity}명</span>
+                                정원 <span style="margin-left:8px; color:#444;">{capacityDisplay}</span>
                             </td>
                         </tr>
                     </table>

--- a/src/main/resources/com/wafflestudio/spring2025/common/email/template/registration-waitlist-promoted.html
+++ b/src/main/resources/com/wafflestudio/spring2025/common/email/template/registration-waitlist-promoted.html
@@ -37,6 +37,7 @@
             </tr>
         </table>
 
+        <a href="{serviceDomain}/event/{publicId}?regId={registrationPublicId}" style="display: block; text-decoration: none; color: inherit;">
         <div style="border: 1px solid #EAEAEA; border-radius: 12px; padding: 24px; margin-bottom: 16px;">
             <div style="font-size: 22px; font-weight: bold; color: #000; margin-bottom: 20px;">{eventTitle}</div>
 
@@ -74,6 +75,7 @@
                 style="text-align: right; color: #CCCCCC; font-size: 24px; line-height: 1; font-family: sans-serif; font-weight: 300; margin-top: -10px;">
                 &rsaquo;</div>
         </div>
+        </a>
 
         <table border="0" cellpadding="0" cellspacing="0"
             style="width: 100%; background-color: #F7F8F9; border-radius: 8px; margin-bottom: 40px;">

--- a/src/main/resources/com/wafflestudio/spring2025/common/email/template/registration-waitlist-promoted.html
+++ b/src/main/resources/com/wafflestudio/spring2025/common/email/template/registration-waitlist-promoted.html
@@ -66,7 +66,7 @@
                              alt="user" width="18" style="display: block; border: 0;">
                     </td>
                     <td style="padding-bottom: 4px; padding-left: 10px; vertical-align: middle;">
-                        정원 <span style="margin-left:8px; color:#444;">{totalCount}/{capacity}명</span>
+                        정원 <span style="margin-left:8px; color:#444;">{capacityDisplay}</span>
                     </td>
                 </tr>
             </table>

--- a/src/main/resources/com/wafflestudio/spring2025/common/email/template/registration-waitlisted.html
+++ b/src/main/resources/com/wafflestudio/spring2025/common/email/template/registration-waitlisted.html
@@ -44,6 +44,7 @@
                     </tr>
                 </table>
 
+                <a href="{serviceDomain}/event/{publicId}?regId={registrationPublicId}" style="display: block; text-decoration: none; color: inherit;">
                 <div style="border: 1px solid #EAEAEA; border-radius: 12px; padding: 24px; margin-bottom: 16px;">
                     <div style="font-size: 20px; font-weight: bold; color: #000; margin-bottom: 20px;">{eventTitle}
                     </div>
@@ -82,6 +83,7 @@
                         style="text-align: right; color: #CCCCCC; font-size: 24px; line-height: 1; font-family: sans-serif; font-weight: 300; margin-top: -10px;">
                         &rsaquo;</div>
                 </div>
+                </a>
 
                 <table border="0" cellpadding="0" cellspacing="0" width="100%"
                     style="background-color: #F7F8F9; border-radius: 8px; margin-bottom: 30px;">

--- a/src/main/resources/com/wafflestudio/spring2025/common/email/template/registration-waitlisted.html
+++ b/src/main/resources/com/wafflestudio/spring2025/common/email/template/registration-waitlisted.html
@@ -74,7 +74,7 @@
                                      alt="user" width="18" style="display: block; border: 0;">
                             </td>
                             <td style="padding-bottom: 4px; padding-left: 10px; vertical-align: middle;">
-                                정원 <span style="margin-left:8px; color:#444;">{totalCount}/{capacity}명</span>
+                                정원 <span style="margin-left:8px; color:#444;">{capacityDisplay}</span>
                             </td>
                         </tr>
                     </table>


### PR DESCRIPTION
## ✨ Feature PR (to dev)

### 🧪 로컬 테스트 여부 (작업자 체크)
- [x] 로컬에서 Swagger 혹은 테스트 코드로 동작을 확인했습니다.
- [x] API 변경이 있다면 `src/main/resources/static/docs/openapi.yaml`을 함께 갱신했습니다.
- [x] `/docs/swagger-ui.html`에서 변경 API가 의도대로 보이는지 확인했습니다.

### 📄 documentation 최신화 여부
> 변경사항과 관련된 API의 swagger documentation이 실제 동작과 일치하는지 확인합니다.
- [x] (작업자) 확인하였습니다.
- [ ] (리뷰어) 확인하였습니다.

### 📌 작업 내용(what & why)

- 이메일 템플릿에서 정원이 7/5명 등 직관적이지 않게 표시되던 부분을 웹페이지와 동일한 정원 5/5명 (대기자 2명) 형식으로 통일했습니다.
- 추가적으로, 이메일 템플릿의 event 정보 카드에 상세정보 페이지 링크를 추가하여 '취소하기' 버튼을 누르지 않고도 정보 페이지로 이동이 가능하게 했습니다.

### 🔥 관련 이슈
- closes #257
