### PR TITLE
refactor: 차단된 사용자 재신청 시도 에러 메시지 개선

### DIFF
--- a/src/main/kotlin/com/wafflestudio/spring2025/domain/registration/exception/RegistrationErrorCode.kt
+++ b/src/main/kotlin/com/wafflestudio/spring2025/domain/registration/exception/RegistrationErrorCode.kt
@@ -74,8 +74,8 @@ enum class RegistrationErrorCode(
 
     REGISTRATION_BLOCKED_BANNED(
         httpStatusCode = HttpStatus.FORBIDDEN,
-        title = "차단된 신청입니다.",
-        message = "차단된 신청은\n다시 신청할 수 없습니다.",
+        title = "차단된 사용자입니다.",
+        message = "해당 모임의 주최자에 의해\n차단되어 신청할 수 없습니다.",
     ),
 
     NOT_WITHIN_REGISTRATION_WINDOW(


### PR DESCRIPTION
기존 "차단된 신청입니다. 차단된 신청은 다시 신청할 수 없습니다." 메시지를
"차단된 사용자입니다. 해당 모임의 주최자에 의해 차단되어 신청할 수 없습니다."로 변경하여 사용자에게 더 명확하고 자연스러운 안내 제공

🤖 Generated with [Claude Code](https://claude.com/claude-code)
